### PR TITLE
Add LiteStar to python auth lib + pre-commit hooks for all code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # HOTOSM Login (SSO)
 
-Centralized authentication service for all HOTOSM applications using Hanko + OSM OAuth.
+Centralized authentication service for all HOTOSM applications using Hanko + OSM
+OAuth.
 
 For context behind this decision, see: [ADR-0011: SSO Authentication](https://docs.hotosm.org/decisions/0011-sso-auth/)
 
@@ -9,11 +10,12 @@ For context behind this decision, see: [ADR-0011: SSO Authentication](https://do
 The login service consists of four main components:
 
 - **Hanko**: Core authentication service (JWT sessions, passkeys, passwords)
-- **Backend**: FastAPI service for custom authentication logic (OSM OAuth, user mapping)
+- **Backend**: FastAPI service for custom auth logic (OSM OAuth, user mapping)
 - **Frontend**: React application for login UI and user management
 - **OSM-userinfo**: Go service for fetching OpenStreetMap user information
 
-All services are orchestrated with Docker Compose and deployed to EC2 with GitHub Actions.
+All services are orchestrated with Docker Compose and deployed to EC2 with
+GitHub Actions.
 
 ## Quick Start (Local Development)
 
@@ -48,7 +50,7 @@ docker compose --profile prod up --build
 
 ### 4. Access the services
 
-**Development mode:**
+### Development mode
 
 - Hanko API: <https://dev.login.hotosm.org>
 - Frontend: <https://app.dev.login.hotosm.org>
@@ -56,7 +58,7 @@ docker compose --profile prod up --build
 - Hanko Elements: <https://elements.login.hotosm.org>
 - Demo: <https://demo.login.hotosm.org>
 
-**Production mode:**
+### Production mode
 
 - Hanko API: <https://login.hotosm.org>
 - Frontend: <https://app.login.hotosm.org>
@@ -121,12 +123,12 @@ docker build -t test-osm-userinfo ./osm-userinfo
 
 ### Auth-libs Integration
 
-**Python library:**
+### Python library
 
 - Located in `auth-libs/python/`
 - Installed via pip during Docker build
 
-**Web component:**
+### Web component
 
 - Source: `frontend/auth-libs/web-component/`
 - Published to npm as `@hotosm/hanko-auth`
@@ -137,7 +139,7 @@ docker build -t test-osm-userinfo ./osm-userinfo
   pnpm add @awesome.me/webawesome  # peer dependency
   ```
 
-**Development:**
+### Web Component Development
 
 - Edit source in respective directories
 - Build web component: `cd frontend/auth-libs/web-component && pnpm build`
@@ -149,14 +151,14 @@ docker build -t test-osm-userinfo ./osm-userinfo
 
 The service deploys automatically to EC2:
 
-**Testing Environment:**
+### Testing Environment
 
 - Branch: `develop`
 - Workflow: `.github/workflows/deploy-testing.yml`
 - Triggered by: Push to `develop` branch
 - Deploys to: EC2 testing server with `--profile dev`
 
-**Production Environment:**
+### Production Environment
 
 - Branch: `main`
 - Workflow: `.github/workflows/deploy-production.yml`
@@ -179,14 +181,14 @@ The service deploys automatically to EC2:
 
 Configure these secrets in GitHub Settings → Environments:
 
-**Environment: Development**
+### Environment: Development
 
 - `EC2_HOST`: Hostname of testing EC2 server
 - `EC2_USER`: SSH user (usually `admin`)
 - `EC2_SSH_KEY`: Private SSH key for EC2 access
 - `POSTGRES_PASSWORD`: PostgreSQL password for Hanko database
 
-**Environment: Production**
+### Environment: Production
 
 - Same secrets but for production EC2 server
 
@@ -218,23 +220,23 @@ docker image prune -af
 
 ### Environment Variables
 
-**Hanko:**
+### Hanko Service
 
 - Configured via `config.yaml` (production) or `config_dev.yaml` (development)
 - See [Hanko documentation](https://docs.hanko.io/) for configuration options
 
-**Backend:**
+### Backend
 
 - `HANKO_URL`: Hanko API URL (default: <http://hanko:8000>)
 - `OSM_CLIENT_ID`: OSM OAuth client ID
 - `OSM_CLIENT_SECRET`: OSM OAuth client secret
 
-**Frontend:**
+### Frontend
 
 - `VITE_HANKO_URL`: Hanko API URL for frontend
 - `VITE_BACKEND_URL`: Backend API URL
 
-**Database:**
+### Database
 
 - `POSTGRES_USER`: Database user (default: hanko)
 - `POSTGRES_PASSWORD`: Database password (set in .env)
@@ -272,7 +274,8 @@ docker compose logs -f frontend
    - Verify auth-libs web component exists in `frontend/auth-libs/web-component/dist/`
 
 3. **Missing auth-libs in Docker build:**
-   - Ensure dist files are committed: `git add -f backend/auth-libs/python/dist/*.whl frontend/auth-libs/web-component/dist/*.js`
+   - Ensure dist files are committed:
+     `git add -f backend/auth-libs/python/dist/*.whl frontend/auth-libs/web-component/dist/*.js`
    - Run distribute script from auth-libs repo
 
 ### Deployment Issues

--- a/auth-libs/README.md
+++ b/auth-libs/README.md
@@ -6,33 +6,34 @@ Shared authentication libraries for all HOTOSM projects.
 
 ### 1. Python Library (`python/`)
 
-**Python library** for FastAPI and Django integration.
+**Python library** for FastAPI, Django, and Litestar integration.
 
 **Installation** (in your `pyproject.toml`):
 
 ```python
 # From PyPI
 dependencies = [
-    "hotosm-auth[fastapi]==0.2.9",
+    "hotosm-auth[fastapi]==0.2.10",
 ]
 
 # Or from Git
 dependencies = [
-    "hotosm-auth[fastapi] @ git+https://github.com/hotosm/login.git@v0.2.9#subdirectory=auth-libs/python",
+    "hotosm-auth[litestar] @ git+https://github.com/hotosm/login.git@v0.2.10#subdirectory=auth-libs/python",
 ]
 ```
 
 **Usage**:
 
 ```python
-from hotosm_auth_fastapi import setup_auth, Auth
+from litestar import Litestar, get
+from hotosm_auth_litestar import setup_auth, Auth
 
-app = FastAPI()
-setup_auth(app)
-
-@app.get("/me")
+@get("/me")
 async def get_me(auth: Auth):
     return {"id": auth.user.id, "email": auth.user.email}
+
+deps, route_handlers = setup_auth()
+app = Litestar(route_handlers=[get_me, *route_handlers], dependencies=deps)
 ```
 
 Full documentation: [python/README.md](./python/README.md)
@@ -65,10 +66,10 @@ Projects can use PyPI or reference directly from GitHub:
 
 ```python
 # PyPI (recommended)
-"hotosm-auth[fastapi]==0.2.9",
+"hotosm-auth[fastapi]==0.2.10",
 
 # Git reference
-"hotosm-auth[fastapi] @ git+https://github.com/hotosm/login.git@v0.2.9#subdirectory=auth-libs/python",
+"hotosm-auth[litestar] @ git+https://github.com/hotosm/login.git@v0.2.10#subdirectory=auth-libs/python",
 ```
 
 - No wheels to distribute or commit
@@ -167,44 +168,44 @@ OSM_CLIENT_SECRET=your-osm-client-secret
 
 #### Core
 
-| Attribute   | Type   | Default                  | Description                                             |
-| ----------- | ------ | ------------------------ | ------------------------------------------------------- |
-| `hanko-url` | string | `window.location.origin` | Hanko API URL for SDK initialization and JWT validation |
-| `login-url` | string | `${hanko-url}/app`       | Login page URL (override for standalone mode)           |
-| `base-path` | string | `""`                     | Base URL for OSM OAuth endpoints                        |
-| `auth-path` | string | `/api/auth/osm`          | OSM auth endpoints path (appended to base-path)         |
+| Attribute | Type | Default | Description |
+| - | - | - | - |
+| `hanko-url` | string | `window.location.origin` | Hanko API URL |
+| `login-url` | string | `${hanko-url}/app` | Login page URL |
+| `base-path` | string | `""` | Base URL for OSM OAuth |
+| `auth-path` | string | `/api/auth/osm` | OSM auth path (under base-path) |
 
 #### Behavior
 
-| Attribute        | Type    | Default        | Description                        |
-| ---------------- | ------- | -------------- | ---------------------------------- |
-| `osm-required`   | boolean | `false`        | Require OSM connection after login |
-| `osm-scopes`     | string  | `"read_prefs"` | Space-separated OSM scopes         |
-| `auto-connect`   | boolean | `false`        | Auto-redirect to OSM OAuth         |
-| `verify-session` | boolean | `false`        | Verify session on return           |
+| Attribute | Type | Default | Description |
+| - | - | - | - |
+| `osm-required` | boolean | `false` | Require OSM connection |
+| `osm-scopes` | string | `"read_prefs"` | Space-separated OSM scopes |
+| `auto-connect` | boolean | `false` | Auto-redirect to OSM OAuth |
+| `verify-session` | boolean | `false` | Verify session on return |
 
 #### Display
 
-| Attribute      | Type    | Default | Description                          |
+| Attribute | Type | Default | Description |
 | -------------- | ------- | ------- | ------------------------------------ |
 | `show-profile` | boolean | `false` | Show embedded form (login page mode) |
-| `display-name` | string  | `""`    | Override display name                |
+| `display-name` | string | `""` | Override display name |
 
 #### Redirects
 
-| Attribute               | Type   | Default | Description                  |
+| Attribute | Type | Default | Description |
 | ----------------------- | ------ | ------- | ---------------------------- |
-| `redirect-after-login`  | string | `""`    | URL to redirect after login  |
-| `redirect-after-logout` | string | `""`    | URL to redirect after logout |
+| `redirect-after-login` | string | `""` | URL to redirect after login |
+| `redirect-after-logout` | string | `""` | URL to redirect after logout |
 
 #### Cross-app
 
-| Attribute           | Type   | Default | Description                            |
-| ------------------- | ------ | ------- | -------------------------------------- |
-| `mapping-check-url` | string | `""`    | URL to check user mapping              |
-| `app-id`            | string | `""`    | App identifier for onboarding redirect |
+| Attribute | Type | Default | Description |
+| - | - | - | - |
+| `mapping-check-url` | string | `""` | Mapping check URL |
+| `app-id` | string | `""` | App ID for onboarding redirect |
 
-**Usage modes:**
+### Usage modes
 
 1. **SSO Mode** (production): Points to login.hotosm.org
 
@@ -239,20 +240,24 @@ uv run pytest
 # Run with FastAPI integration tests
 uv run --extra fastapi pytest
 
+# Run with Litestar integration tests
+uv run --extra litestar pytest
+
 # Run with Django integration tests
 uv run --extra django pytest
 
-# Run all tests (127 tests)
-uv run --extra fastapi --extra django pytest
+# Run all tests
+uv run --extra fastapi --extra litestar --extra django pytest
 
-# Run with coverage (72% coverage)
-uv run --extra fastapi --extra django pytest --cov=src --cov-report=term-missing
+# Run with coverage
+uv run --extra fastapi --extra litestar --extra django pytest --cov=src --cov-report=term-missing
 ```
 
 **Test categories:**
 
 - Core: config, crypto, JWT validation, OSM OAuth client
 - FastAPI: dependencies, OSM routes, admin routes
+- Litestar: dependencies, OSM routes, admin routes
 - Django: middleware, OSM views, admin routes
 
 ### Web Component
@@ -276,22 +281,22 @@ pnpm build
 
 ### Backend (Python)
 
-| Project       | File                              |
+| Project | File |
 | ------------- | --------------------------------- |
-| portal        | `backend/pyproject.toml`          |
-| drone-tm      | `src/backend/pyproject.toml`      |
-| fAIr          | `backend/pyproject.toml`          |
+| portal | `backend/pyproject.toml` |
+| drone-tm | `src/backend/pyproject.toml` |
+| fAIr | `backend/pyproject.toml` |
 | openaerialmap | `backend/stac-api/pyproject.toml` |
 
 ### Frontend (Web Component)
 
-| Project       | Location                                     |
+| Project | Location |
 | ------------- | -------------------------------------------- |
-| portal        | `frontend/auth-libs/web-component/dist/`     |
-| drone-tm      | `src/frontend/auth-libs/web-component/dist/` |
-| fAIr          | `frontend/auth-libs/web-component/dist/`     |
-| openaerialmap | `frontend/auth-libs/web-component/dist/`     |
-| login         | `frontend/auth-libs/web-component/dist/`     |
+| portal | `frontend/auth-libs/web-component/dist/` |
+| drone-tm | `src/frontend/auth-libs/web-component/dist/` |
+| fAIr | `frontend/auth-libs/web-component/dist/` |
+| openaerialmap | `frontend/auth-libs/web-component/dist/` |
+| login | `frontend/auth-libs/web-component/dist/` |
 
 ---
 

--- a/auth-libs/python/README.md
+++ b/auth-libs/python/README.md
@@ -1,6 +1,7 @@
 # HOTOSM Auth Library - Python
 
-FastAPI/Django integration for Hanko SSO authentication with OSM OAuth support.
+FastAPI, Litestar, and Django integration for Hanko SSO authentication with OSM
+OAuth support.
 
 ## Installation
 
@@ -13,6 +14,9 @@ pip install hotosm-auth[fastapi]
 
 # With Django support
 pip install hotosm-auth[django]
+
+# With Litestar support
+pip install hotosm-auth[litestar]
 ```
 
 ## Usage
@@ -46,6 +50,22 @@ def my_view(request):
     return JsonResponse({"user_id": request.hotosm.user.id})
 ```
 
+### Litestar
+
+```python
+from litestar import Litestar, get
+from hotosm_auth_litestar import setup_auth, Auth
+
+
+@get("/me")
+async def me(auth: Auth):
+    return {"id": auth.user.id, "email": auth.user.email}
+
+
+deps, route_handlers = setup_auth()
+app = Litestar(route_handlers=[me, *route_handlers], dependencies=deps)
+```
+
 ## Configuration
 
 Set these environment variables:
@@ -77,11 +97,15 @@ uv run --extra fastapi pytest
 # Run with Django tests
 uv run --extra django pytest
 
-# Run all tests (FastAPI + Django)
-uv run --extra fastapi --extra django pytest
+# Run with Litestar tests
+uv run --extra litestar pytest
+
+# Run all tests (FastAPI + Litestar + Django)
+uv run --extra fastapi --extra litestar --extra django pytest
 
 # Run with coverage
-uv run --extra fastapi --extra django pytest --cov=src --cov-report=term-missing
+uv run --extra fastapi --extra litestar --extra django pytest --cov=src \
+  --cov-report=term-missing
 ```
 
 ### Test Structure
@@ -101,8 +125,17 @@ uv run --extra fastapi --extra django pytest --cov=src --cov-report=term-missing
 
 - `tests/test_fastapi_setup.py` - Auth dependency setup
 - `tests/test_fastapi_dependencies.py` - Dependency injection with mocked requests
-- `tests/test_fastapi_osm_routes.py` - OSM OAuth routes (login, callback, status, disconnect)
+- `tests/test_fastapi_osm_routes.py` - OSM OAuth routes (login, callback,
+  status, disconnect)
 - `tests/test_admin_routes.py` - Admin CRUD routes with mocked database
+
+**Litestar tests** (require `[litestar]` extra):
+
+- `tests/test_litestar_setup.py` - Auth context and setup API
+- `tests/test_litestar_dependencies.py` - Dependency helpers with mocked requests
+- `tests/test_litestar_osm_routes.py` - OSM OAuth routes (login, callback,
+  status, disconnect)
+- `tests/test_litestar_admin_routes.py` - Admin CRUD routes with mocked database
 
 **Django tests** (require `[django]` extra):
 
@@ -115,7 +148,7 @@ uv run --extra fastapi --extra django pytest --cov=src --cov-report=term-missing
 Run with coverage report:
 
 ```bash
-uv run --extra fastapi --extra django pytest --cov=src --cov-report=term-missing
+uv run --extra fastapi --extra litestar --extra django pytest --cov=src --cov-report=term-missing
 ```
 
 Current coverage: **72%** (127 tests)
@@ -126,7 +159,7 @@ Current coverage: **72%** (127 tests)
 - OSM OAuth 2.0 integration
 - Encrypted httpOnly cookies for OSM connection
 - User mapping between Hanko and application users
-- FastAPI and Django integrations
+- FastAPI, Litestar, and Django integrations
 
 ## License
 

--- a/auth-libs/python/pyproject.toml
+++ b/auth-libs/python/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "AGPL-3.0" }
 authors = [
     { name = "HOTOSM", email = "tech@hotosm.org" },
 ]
-keywords = ["hotosm", "auth", "hanko", "osm", "oauth", "sso", "fastapi", "django"]
+keywords = ["hotosm", "auth", "hanko", "osm", "oauth", "sso", "fastapi", "django", "litestar"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -43,6 +43,10 @@ django = [
     "django>=4.2.0",
     "djangorestframework>=3.14.0",
 ]
+litestar = [
+    "litestar>=2.0.0",
+    "psycopg>=3.0.0",
+]
 dev = [
     "pytest>=7.4.0",
     "pytest-asyncio>=0.21.0",
@@ -50,6 +54,7 @@ dev = [
     "black>=23.0.0",
     "ruff>=0.1.0",
     "mypy>=1.5.0",
+    "psycopg>=3.0.0",
 ]
 
 [project.urls]

--- a/auth-libs/python/src/hotosm_auth_litestar/__init__.py
+++ b/auth-libs/python/src/hotosm_auth_litestar/__init__.py
@@ -1,0 +1,95 @@
+"""hotosm_auth_litestar: Litestar integration for HOTOSM authentication.
+
+This package provides Litestar-specific functionality:
+- Dependency injection for authentication
+- Admin routes for managing user mappings (psycopg)
+- OSM OAuth routes
+
+Quick Start:
+    from litestar import Litestar
+    from hotosm_auth_litestar import setup_auth, AuthContext
+
+    deps, route_handlers = setup_auth()
+    app = Litestar(route_handlers=route_handlers, dependencies=deps)
+
+    @get("/me")
+    async def me(auth: AuthContext) -> dict:
+        return {"user": auth.user.email}
+
+For more control:
+    from hotosm_auth_litestar import (
+        init_auth,
+        create_dependencies,
+        get_current_user,
+        get_current_user_optional,
+    )
+"""
+
+# Core dependencies
+# Admin functionality
+from hotosm_auth_litestar.admin import AdminUser, require_admin
+from hotosm_auth_litestar.admin_routes import (
+    create_admin_mappings_router,
+)
+from hotosm_auth_litestar.dependencies import (
+    AuthContext,
+    OptionalAuthContext,
+    clear_osm_cookie,
+    create_dependencies,
+    create_user_mapping,
+    get_config,
+    get_cookie_crypto,
+    get_current_user,
+    get_current_user_optional,
+    get_jwt_validator,
+    get_mapped_user_id,
+    get_osm_connection,
+    init_auth,
+    provide_auth_context,
+    provide_optional_auth_context,
+    require_osm_connection,
+    set_osm_cookie,
+)
+
+# OSM routes
+from hotosm_auth_litestar.osm_routes import osm_router
+
+# Simple setup API
+from hotosm_auth_litestar.setup import setup_auth
+
+# Type aliases matching FastAPI naming conventions
+Auth = AuthContext
+OptionalAuth = OptionalAuthContext
+
+__all__ = [
+    # Setup
+    "setup_auth",
+    "init_auth",
+    "create_dependencies",
+    # Auth contexts
+    "AuthContext",
+    "OptionalAuthContext",
+    "Auth",
+    "OptionalAuth",
+    # Dependencies
+    "get_config",
+    "get_jwt_validator",
+    "get_cookie_crypto",
+    "get_current_user",
+    "get_current_user_optional",
+    "get_osm_connection",
+    "require_osm_connection",
+    "set_osm_cookie",
+    "clear_osm_cookie",
+    "get_mapped_user_id",
+    "create_user_mapping",
+    # Dependency providers
+    "provide_auth_context",
+    "provide_optional_auth_context",
+    # Admin
+    "require_admin",
+    "AdminUser",
+    "create_admin_mappings_router",
+    # Routes
+    "osm_router",
+]

--- a/auth-libs/python/src/hotosm_auth_litestar/admin.py
+++ b/auth-libs/python/src/hotosm_auth_litestar/admin.py
@@ -1,0 +1,42 @@
+"""Litestar admin authentication helpers."""
+
+from litestar.exceptions import HTTPException
+from litestar.status_codes import HTTP_403_FORBIDDEN
+
+from hotosm_auth.logger import get_logger
+from hotosm_auth.models import HankoUser
+from hotosm_auth_litestar.dependencies import get_config
+
+logger = get_logger(__name__)
+
+AdminUser = HankoUser
+
+
+async def require_admin(current_user: HankoUser) -> HankoUser:
+    """Require admin access based on email whitelist."""
+    config = get_config()
+    admin_emails = config.admin_email_list
+
+    if not admin_emails:
+        logger.warning("ADMIN_EMAILS is not configured - admin access denied")
+        raise HTTPException(
+            status_code=HTTP_403_FORBIDDEN,
+            detail="Admin access not configured",
+        )
+
+    if not current_user.email:
+        logger.warning(f"User {current_user.id} has no email - admin access denied")
+        raise HTTPException(
+            status_code=HTTP_403_FORBIDDEN,
+            detail="Admin access requires verified email",
+        )
+
+    if current_user.email.lower() not in admin_emails:
+        logger.warning(f"User {current_user.email} is not an admin - access denied")
+        raise HTTPException(
+            status_code=HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+
+    logger.info(f"Admin access granted to {current_user.email}")
+    return current_user

--- a/auth-libs/python/src/hotosm_auth_litestar/admin_routes.py
+++ b/auth-libs/python/src/hotosm_auth_litestar/admin_routes.py
@@ -1,0 +1,292 @@
+"""Litestar admin routes for managing user mappings (psycopg version)."""
+
+from collections.abc import Callable
+from typing import Any
+
+from litestar import Router, delete, get, post, put
+from litestar.di import Provide
+from litestar.exceptions import HTTPException
+from litestar.params import Parameter
+from litestar.status_codes import (
+    HTTP_201_CREATED,
+    HTTP_204_NO_CONTENT,
+    HTTP_404_NOT_FOUND,
+    HTTP_409_CONFLICT,
+)
+from psycopg import sql
+
+from hotosm_auth.logger import get_logger
+from hotosm_auth.schemas.admin import (
+    MappingCreate,
+    MappingListResponse,
+    MappingResponse,
+    MappingUpdate,
+)
+from hotosm_auth_litestar.admin import AdminUser, require_admin
+
+logger = get_logger(__name__)
+_LIST_ROW_USERNAME_INDEX = 5
+_LIST_ROW_EMAIL_INDEX = 6
+
+
+def _build_list_mappings_query(
+    user_table: str | None,
+    user_name_column: str,
+    user_email_column: str,
+    user_id_column: str,
+) -> str | sql.Composed:
+    """Build SQL query for listing mappings with optional user enrichment."""
+    if user_table:
+        return sql.SQL(
+            """
+            SELECT
+                m.hanko_user_id,
+                m.app_user_id,
+                m.app_name,
+                m.created_at,
+                m.updated_at,
+                u.{user_name_column} AS app_username,
+                u.{user_email_column} AS app_email
+            FROM hanko_user_mappings m
+            LEFT JOIN {user_table} u
+                ON m.app_user_id = u.{user_id_column}::text
+            WHERE m.app_name = %s
+            ORDER BY m.created_at DESC
+            LIMIT %s OFFSET %s
+            """
+        ).format(
+            user_name_column=sql.Identifier(user_name_column),
+            user_email_column=sql.Identifier(user_email_column),
+            user_table=sql.Identifier(user_table),
+            user_id_column=sql.Identifier(user_id_column),
+        )
+
+    return """
+        SELECT hanko_user_id, app_user_id, app_name, created_at, updated_at,
+               NULL as app_username, NULL as app_email
+        FROM hanko_user_mappings
+        WHERE app_name = %s
+        ORDER BY created_at DESC
+        LIMIT %s OFFSET %s
+    """
+
+
+def _mapping_response_from_row(row: tuple) -> MappingResponse:
+    """Convert a DB row tuple into a MappingResponse."""
+    return MappingResponse(
+        hanko_user_id=row[0],
+        app_user_id=row[1],
+        app_name=row[2],
+        created_at=row[3],
+        updated_at=row[4],
+        app_username=(
+            row[_LIST_ROW_USERNAME_INDEX]
+            if len(row) > _LIST_ROW_USERNAME_INDEX
+            else None
+        ),
+        app_email=(
+            row[_LIST_ROW_EMAIL_INDEX] if len(row) > _LIST_ROW_EMAIL_INDEX else None
+        ),
+    )
+
+
+def create_admin_mappings_router(  # noqa: C901, PLR0915
+    get_db: Callable,
+    app_name: str = "default",
+    user_table: str | None = None,
+    user_id_column: str = "id",
+    user_name_column: str = "name",
+    user_email_column: str = "email",
+) -> Router:
+    """Create a Litestar router for mapping CRUD using psycopg."""
+
+    @get("/mappings")
+    async def list_mappings(
+        admin_user: AdminUser,
+        db: Any,
+        page: int = Parameter(ge=1, default=1),
+        page_size: int = Parameter(ge=1, le=100, default=50),
+    ) -> MappingListResponse:
+        """List mappings for the configured application."""
+        offset = (page - 1) * page_size
+
+        async with db.cursor() as cur:
+            await cur.execute(
+                "SELECT COUNT(*) FROM hanko_user_mappings WHERE app_name = %s",
+                (app_name,),
+            )
+            count_row = await cur.fetchone()
+            total = count_row[0] if count_row else 0
+
+            query = _build_list_mappings_query(
+                user_table,
+                user_name_column,
+                user_email_column,
+                user_id_column,
+            )
+            await cur.execute(query, (app_name, page_size, offset))
+            rows = await cur.fetchall()
+
+        logger.info(
+            "Admin %s listed mappings (page=%s, total=%s)",
+            admin_user.email,
+            page,
+            total,
+        )
+
+        return MappingListResponse(
+            items=[_mapping_response_from_row(row) for row in rows],
+            total=total,
+            page=page,
+            page_size=page_size,
+        )
+
+    @get("/mappings/{hanko_user_id:str}")
+    async def get_mapping(
+        hanko_user_id: str,
+        admin_user: AdminUser,
+        db: Any,
+    ) -> MappingResponse:
+        """Get a mapping by Hanko user ID."""
+        async with db.cursor() as cur:
+            await cur.execute(
+                """
+                SELECT hanko_user_id, app_user_id, app_name, created_at, updated_at
+                FROM hanko_user_mappings
+                WHERE hanko_user_id = %s AND app_name = %s
+                """,
+                (hanko_user_id, app_name),
+            )
+            row = await cur.fetchone()
+
+        if not row:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND,
+                detail=f"Mapping not found for hanko_user_id: {hanko_user_id}",
+            )
+
+        logger.info("Admin %s retrieved mapping %s", admin_user.email, hanko_user_id)
+
+        return _mapping_response_from_row(row)
+
+    @post("/mappings", status_code=HTTP_201_CREATED)
+    async def create_mapping(
+        data: MappingCreate,
+        admin_user: AdminUser,
+        db: Any,
+    ) -> MappingResponse:
+        """Create a new Hanko-to-app user mapping."""
+        async with db.cursor() as cur:
+            await cur.execute(
+                """
+                SELECT 1 FROM hanko_user_mappings
+                WHERE hanko_user_id = %s AND app_name = %s
+                """,
+                (data.hanko_user_id, app_name),
+            )
+            if await cur.fetchone():
+                raise HTTPException(
+                    status_code=HTTP_409_CONFLICT,
+                    detail=(
+                        "Mapping already exists for "
+                        f"hanko_user_id: {data.hanko_user_id}"
+                    ),
+                )
+
+            await cur.execute(
+                """
+                INSERT INTO hanko_user_mappings (
+                    hanko_user_id, app_user_id, app_name, created_at
+                )
+                VALUES (%s, %s, %s, NOW())
+                RETURNING hanko_user_id, app_user_id, app_name, created_at, updated_at
+                """,
+                (data.hanko_user_id, data.app_user_id, app_name),
+            )
+            row = await cur.fetchone()
+
+        logger.info(
+            "Admin %s created mapping: %s -> %s",
+            admin_user.email,
+            data.hanko_user_id,
+            data.app_user_id,
+        )
+
+        return _mapping_response_from_row(row)
+
+    @put("/mappings/{hanko_user_id:str}")
+    async def update_mapping(
+        hanko_user_id: str,
+        data: MappingUpdate,
+        admin_user: AdminUser,
+        db: Any,
+    ) -> MappingResponse:
+        """Update an existing mapping's application user ID."""
+        async with db.cursor() as cur:
+            await cur.execute(
+                """
+                UPDATE hanko_user_mappings
+                SET app_user_id = %s, updated_at = NOW()
+                WHERE hanko_user_id = %s AND app_name = %s
+                RETURNING hanko_user_id, app_user_id, app_name, created_at, updated_at
+                """,
+                (data.app_user_id, hanko_user_id, app_name),
+            )
+            row = await cur.fetchone()
+
+        if not row:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND,
+                detail=f"Mapping not found for hanko_user_id: {hanko_user_id}",
+            )
+
+        logger.info(
+            "Admin %s updated mapping: %s -> %s",
+            admin_user.email,
+            hanko_user_id,
+            data.app_user_id,
+        )
+
+        return _mapping_response_from_row(row)
+
+    @delete("/mappings/{hanko_user_id:str}", status_code=HTTP_204_NO_CONTENT)
+    async def delete_mapping(
+        hanko_user_id: str,
+        admin_user: AdminUser,
+        db: Any,
+    ) -> None:
+        """Delete a mapping for the configured application."""
+        async with db.cursor() as cur:
+            await cur.execute(
+                """
+                DELETE FROM hanko_user_mappings
+                WHERE hanko_user_id = %s AND app_name = %s
+                RETURNING hanko_user_id
+                """,
+                (hanko_user_id, app_name),
+            )
+            row = await cur.fetchone()
+
+        if not row:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND,
+                detail=f"Mapping not found for hanko_user_id: {hanko_user_id}",
+            )
+
+        logger.info("Admin %s deleted mapping: %s", admin_user.email, hanko_user_id)
+
+    return Router(
+        path="/admin",
+        route_handlers=[
+            list_mappings,
+            get_mapping,
+            create_mapping,
+            update_mapping,
+            delete_mapping,
+        ],
+        tags=["Admin"],
+        dependencies={
+            "admin_user": Provide(require_admin),
+            "db": Provide(get_db),
+        },
+    )

--- a/auth-libs/python/src/hotosm_auth_litestar/dependencies.py
+++ b/auth-libs/python/src/hotosm_auth_litestar/dependencies.py
@@ -1,0 +1,374 @@
+"""Litestar dependencies for HOTOSM authentication.
+
+Provides:
+- Dependency providers for HankoUser and OSMConnection
+- Cookie management utilities
+- User mapping helpers
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from litestar import Request, Response
+from litestar.di import Provide
+from litestar.exceptions import HTTPException
+from litestar.status_codes import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
+
+from hotosm_auth.config import AuthConfig
+from hotosm_auth.crypto import CookieCrypto
+from hotosm_auth.exceptions import (
+    AuthenticationError,
+    CookieDecryptionError,
+    TokenExpiredError,
+    TokenInvalidError,
+)
+from hotosm_auth.jwt_validator import JWTValidator
+from hotosm_auth.logger import get_logger, log_auth_event
+from hotosm_auth.models import HankoUser, OSMConnection
+
+logger = get_logger(__name__)
+_BEARER_PARTS_COUNT = 2
+
+
+# Global instances (set by init_auth)
+_config: AuthConfig | None = None
+_jwt_validator: JWTValidator | None = None
+_cookie_crypto: CookieCrypto | None = None
+
+
+@dataclass
+class AuthContext:
+    """Combined authenticated context for Litestar handlers."""
+
+    user: HankoUser
+    osm: OSMConnection | None
+
+    def require_osm(self) -> OSMConnection:
+        """Require OSM connection or raise 403."""
+        if not self.osm:
+            raise HTTPException(
+                status_code=HTTP_403_FORBIDDEN,
+                detail="OSM connection required. Please connect your OSM account.",
+            )
+        return self.osm
+
+
+@dataclass
+class OptionalAuthContext:
+    """Combined optional auth context for Litestar handlers."""
+
+    user: HankoUser | None
+    osm: OSMConnection | None
+
+
+def init_auth(config: AuthConfig) -> None:
+    """Initialize authentication for Litestar app."""
+    global _config, _jwt_validator, _cookie_crypto
+
+    _config = config
+    _jwt_validator = JWTValidator(config)
+    _cookie_crypto = CookieCrypto(config.cookie_secret)
+
+
+def get_config() -> AuthConfig:
+    """Get authentication configuration."""
+    if _config is None:
+        raise RuntimeError("Auth not initialized. Call init_auth() at startup.")
+    return _config
+
+
+def get_jwt_validator() -> JWTValidator:
+    """Get JWT validator."""
+    if _jwt_validator is None:
+        raise RuntimeError("Auth not initialized. Call init_auth() at startup.")
+    return _jwt_validator
+
+
+def get_cookie_crypto() -> CookieCrypto:
+    """Get cookie crypto."""
+    if _cookie_crypto is None:
+        raise RuntimeError("Auth not initialized. Call init_auth() at startup.")
+    return _cookie_crypto
+
+
+def get_token_from_request(request: Request) -> str | None:
+    """Extract JWT token from Authorization header or cookie."""
+    authorization = request.headers.get("authorization")
+    if authorization:
+        parts = authorization.split(" ", 1)
+        if (
+            len(parts) == _BEARER_PARTS_COUNT
+            and parts[0].lower() == "bearer"
+            and parts[1]
+        ):
+            return parts[1]
+
+    return request.cookies.get("hanko")
+
+
+async def get_current_user(request: Request) -> HankoUser:
+    """Get currently authenticated user or raise 401."""
+    token = get_token_from_request(request)
+    if not token:
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    validator = get_jwt_validator()
+    try:
+        return await validator.validate_token(token)
+    except TokenExpiredError as exc:
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail="Token has expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+    except (TokenInvalidError, AuthenticationError) as exc:
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail=str(exc),
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+
+async def get_current_user_optional(request: Request) -> HankoUser | None:
+    """Get current user if authenticated, None otherwise."""
+    token = get_token_from_request(request)
+    if not token:
+        return None
+
+    validator = get_jwt_validator()
+    try:
+        return await validator.validate_token(token)
+    except (TokenExpiredError, TokenInvalidError, AuthenticationError):
+        return None
+
+
+def get_osm_connection(request: Request) -> OSMConnection | None:
+    """Get OSM connection from encrypted cookie."""
+    encrypted = request.cookies.get("osm_connection")
+    if not encrypted:
+        return None
+
+    try:
+        return get_cookie_crypto().decrypt_osm_connection(encrypted)
+    except CookieDecryptionError:
+        return None
+
+
+def require_osm_connection(osm_connection: OSMConnection | None) -> OSMConnection:
+    """Require OSM connection."""
+    if not osm_connection:
+        raise HTTPException(
+            status_code=HTTP_403_FORBIDDEN,
+            detail="OSM connection required",
+        )
+    return osm_connection
+
+
+async def provide_auth_context(
+    current_user: HankoUser,
+    osm_connection: OSMConnection | None,
+) -> AuthContext:
+    """Dependency provider for full auth context."""
+    return AuthContext(user=current_user, osm=osm_connection)
+
+
+async def provide_optional_auth_context(
+    current_user_optional: HankoUser | None,
+    osm_connection: OSMConnection | None,
+) -> OptionalAuthContext:
+    """Dependency provider for optional auth context."""
+    return OptionalAuthContext(user=current_user_optional, osm=osm_connection)
+
+
+def create_dependencies() -> dict[str, Provide]:
+    """Create Litestar dependency mapping for HOTOSM auth."""
+    return {
+        "current_user": Provide(get_current_user),
+        "current_user_optional": Provide(get_current_user_optional),
+        "osm_connection": Provide(get_osm_connection, sync_to_thread=False),
+        "osm_connection_required": Provide(
+            require_osm_connection, sync_to_thread=False
+        ),
+        "auth": Provide(provide_auth_context),
+        "optional_auth": Provide(provide_optional_auth_context),
+    }
+
+
+def set_osm_cookie(
+    response: Response,
+    osm_connection: OSMConnection,
+    config: AuthConfig,
+    crypto: CookieCrypto,
+) -> None:
+    """Set encrypted OSM connection cookie on response."""
+    encrypted = crypto.encrypt_osm_connection(osm_connection)
+
+    max_age = None
+    if osm_connection.expires_at:
+        delta = osm_connection.expires_at - datetime.now(timezone.utc)
+        max_age = int(delta.total_seconds())
+
+    response.set_cookie(
+        key="osm_connection",
+        value=encrypted,
+        httponly=True,
+        secure=config.cookie_secure,
+        samesite=config.cookie_samesite,
+        domain=config.cookie_domain,
+        max_age=max_age,
+        path="/",
+    )
+
+
+def clear_osm_cookie(
+    response: Response,
+    config: AuthConfig,
+) -> None:
+    """Clear OSM connection cookie from response."""
+    for secure in [True, False]:
+        for samesite in ["lax", "strict", "none"]:
+            if samesite == "none" and not secure:
+                continue
+            if config.cookie_domain:
+                response.set_cookie(
+                    key="osm_connection",
+                    value="",
+                    httponly=True,
+                    secure=secure,
+                    samesite=samesite,
+                    domain=config.cookie_domain,
+                    max_age=0,
+                    path="/",
+                )
+            response.set_cookie(
+                key="osm_connection",
+                value="",
+                httponly=True,
+                secure=secure,
+                samesite=samesite,
+                max_age=0,
+                path="/",
+            )
+
+
+async def get_mapped_user_id(
+    hanko_user: HankoUser,
+    db_conn,
+    app_name: str = "default",
+    auto_create: bool = True,
+    email_lookup_fn=None,
+    user_creator_fn=None,
+    user_id_generator=None,
+) -> str:
+    """Get application-specific user ID for a Hanko user."""
+    async with db_conn.cursor() as cur:
+        await cur.execute(
+            """
+            SELECT app_user_id
+            FROM hanko_user_mappings
+            WHERE hanko_user_id = %s AND app_name = %s
+            """,
+            (hanko_user.id, app_name),
+        )
+        row = await cur.fetchone()
+
+        if row:
+            app_user_id = row[0]
+            log_auth_event(
+                "MAPPING_FOUND",
+                app_name,
+                hanko_user.id,
+                email=hanko_user.email,
+                app_user_id=app_user_id,
+            )
+            return app_user_id
+
+        if not auto_create:
+            raise HTTPException(
+                status_code=HTTP_403_FORBIDDEN,
+                detail=f"User not authorized for {app_name}",
+            )
+
+        new_user_id = await _resolve_new_user_id(
+            hanko_user,
+            db_conn,
+            email_lookup_fn,
+            user_creator_fn,
+            user_id_generator,
+        )
+
+        await cur.execute(
+            """
+            INSERT INTO hanko_user_mappings (
+                hanko_user_id, app_user_id, app_name, created_at
+            )
+            VALUES (%s, %s, %s, NOW())
+            """,
+            (hanko_user.id, new_user_id, app_name),
+        )
+
+        log_auth_event(
+            "MAPPING_CREATED",
+            app_name,
+            hanko_user.id,
+            email=hanko_user.email,
+            app_user_id=new_user_id,
+        )
+        return new_user_id
+
+
+async def _resolve_new_user_id(
+    hanko_user: HankoUser,
+    db_conn,
+    email_lookup_fn,
+    user_creator_fn,
+    user_id_generator,
+) -> str:
+    """Resolve a new app user ID using lookup, creation, or fallback."""
+    new_user_id = None
+
+    if email_lookup_fn:
+        existing_user_id = await email_lookup_fn(db_conn, hanko_user.email)
+        if existing_user_id:
+            new_user_id = existing_user_id
+
+    if not new_user_id and user_creator_fn:
+        new_user_id = await user_creator_fn(db_conn, hanko_user)
+
+    if new_user_id:
+        return new_user_id
+    return user_id_generator() if user_id_generator else hanko_user.id
+
+
+async def create_user_mapping(
+    hanko_user_id: str,
+    app_user_id: str,
+    db_conn,
+    app_name: str = "default",
+) -> None:
+    """Manually create a user mapping."""
+    async with db_conn.cursor() as cur:
+        await cur.execute(
+            """
+            INSERT INTO hanko_user_mappings (
+                hanko_user_id, app_user_id, app_name, created_at
+            )
+            VALUES (%s, %s, %s, NOW())
+            """,
+            (hanko_user_id, app_user_id, app_name),
+        )
+
+    logger.info(
+        f"Manually created mapping: {hanko_user_id} -> {app_user_id} ({app_name})"
+    )
+    log_auth_event(
+        "MAPPING_CREATED",
+        app_name,
+        hanko_user_id,
+        app_user_id=app_user_id,
+        source="manual",
+    )

--- a/auth-libs/python/src/hotosm_auth_litestar/osm_routes.py
+++ b/auth-libs/python/src/hotosm_auth_litestar/osm_routes.py
@@ -1,0 +1,137 @@
+"""Auto-registered OSM OAuth routes for Litestar."""
+
+import secrets
+from urllib.parse import urlparse
+
+from litestar import Request, Response, Router, get, post
+from litestar.exceptions import HTTPException
+from litestar.params import Parameter
+from litestar.response import Redirect
+from litestar.status_codes import HTTP_200_OK
+
+from hotosm_auth.exceptions import OSMOAuthError
+from hotosm_auth.logger import get_logger
+from hotosm_auth.models import HankoUser, OSMConnection
+from hotosm_auth.osm_oauth import OSMOAuthClient
+from hotosm_auth_litestar.dependencies import (
+    clear_osm_cookie,
+    get_config,
+    get_cookie_crypto,
+    set_osm_cookie,
+)
+
+logger = get_logger(__name__)
+
+# In-memory state storage (use Redis in production)
+# Format: {state: {"user_id": str, "redirect_url": str}}
+_oauth_states: dict[str, dict[str, str]] = {}
+
+
+@get("/login")
+async def osm_login(
+    current_user: HankoUser,
+    request: Request,
+) -> Redirect:
+    """Start OSM OAuth flow and redirect to OSM authorization."""
+    config = get_config()
+    if not config.osm_enabled:
+        raise HTTPException(status_code=400, detail="OSM OAuth is not enabled")
+
+    osm_client = OSMOAuthClient(config)
+    state = secrets.token_urlsafe(32)
+
+    referer = request.headers.get("referer", "")
+    if referer:
+        parsed = urlparse(referer)
+        redirect_url = parsed.path
+        if parsed.query:
+            redirect_url += f"?{parsed.query}"
+    else:
+        path = str(request.url.path)
+        redirect_url = path.rsplit("/auth/osm/login", 1)[0] or "/"
+
+    _oauth_states[state] = {"user_id": current_user.id, "redirect_url": redirect_url}
+    return Redirect(path=osm_client.get_authorization_url(state=state))
+
+
+@get("/callback")
+async def osm_callback(
+    code: str,
+    current_user: HankoUser,
+    oauth_state: str = Parameter(query="state"),
+) -> Redirect:
+    """Handle OSM OAuth callback and set OSM cookie."""
+    config = get_config()
+    if not config.osm_enabled:
+        raise HTTPException(status_code=400, detail="OSM OAuth is not enabled")
+
+    state_data = _oauth_states.pop(oauth_state, None)
+    if not state_data:
+        raise HTTPException(status_code=400, detail="Invalid OAuth state")
+
+    if state_data.get("user_id") != current_user.id:
+        raise HTTPException(status_code=400, detail="Invalid OAuth state")
+
+    try:
+        osm_client = OSMOAuthClient(config)
+        osm_connection = await osm_client.exchange_code(code)
+
+        redirect_url = state_data.get("redirect_url", "/")
+        redirect = Redirect(path=redirect_url, status_code=303)
+        set_osm_cookie(redirect, osm_connection, config, get_cookie_crypto())
+        return redirect
+    except OSMOAuthError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"OSM OAuth failed: {exc}",
+        ) from exc
+
+
+@get("/status")
+async def osm_status(
+    osm_connection: OSMConnection | None,
+) -> dict[str, object]:
+    """Check OSM connection status."""
+    if not osm_connection:
+        return {"connected": False}
+    return {
+        "connected": True,
+        "osm_user_id": osm_connection.osm_user_id,
+        "osm_username": osm_connection.osm_username,
+        "osm_avatar_url": osm_connection.osm_avatar_url,
+    }
+
+
+@post("/disconnect", status_code=HTTP_200_OK)
+async def osm_disconnect(
+    osm_connection: OSMConnection | None,
+) -> Response:
+    """Disconnect OSM account and clear OSM cookie."""
+    config = get_config()
+    tokens_revoked = False
+
+    if osm_connection and config.osm_enabled:
+        try:
+            osm_client = OSMOAuthClient(config)
+            if osm_connection.access_token:
+                await osm_client.revoke_token(
+                    osm_connection.access_token, "access_token"
+                )
+            if osm_connection.refresh_token:
+                await osm_client.revoke_token(
+                    osm_connection.refresh_token, "refresh_token"
+                )
+            tokens_revoked = True
+        except Exception as exc:  # pragma: no cover - best-effort cleanup
+            logger.error(f"Failed to revoke OSM tokens: {exc}")
+
+    response = Response({"status": "disconnected", "tokens_revoked": tokens_revoked})
+    clear_osm_cookie(response, config)
+    return response
+
+
+osm_router = Router(
+    path="/auth/osm",
+    route_handlers=[osm_login, osm_callback, osm_status, osm_disconnect],
+    tags=["OSM OAuth"],
+)

--- a/auth-libs/python/src/hotosm_auth_litestar/setup.py
+++ b/auth-libs/python/src/hotosm_auth_litestar/setup.py
@@ -1,0 +1,66 @@
+"""Simplified setup API for Litestar authentication.
+
+Usage:
+    from litestar import Litestar
+    from hotosm_auth_litestar import setup_auth
+
+    deps, route_handlers = setup_auth()
+    app = Litestar(route_handlers=route_handlers, dependencies=deps)
+
+Or with custom config:
+    from hotosm_auth import AuthConfig
+
+    config = AuthConfig(hanko_api_url="...", cookie_secret="...", osm_enabled=True)
+    deps, route_handlers = setup_auth(config=config)
+    app = Litestar(route_handlers=route_handlers, dependencies=deps)
+"""
+
+from litestar import Router
+from litestar.di import Provide
+
+from hotosm_auth.config import AuthConfig
+from hotosm_auth.logger import get_logger
+from hotosm_auth_litestar.dependencies import create_dependencies, init_auth
+from hotosm_auth_litestar.osm_routes import osm_router
+
+logger = get_logger(__name__)
+
+
+def setup_auth(
+    config: AuthConfig | None = None,
+    auto_osm_routes: bool = True,
+) -> tuple[dict[str, Provide], list[Router]]:
+    """Setup HOTOSM authentication for a Litestar app.
+
+    Initializes auth and returns (dependencies, route_handlers) to pass
+    directly to ``Litestar()``.
+
+    Litestar freezes dependencies at init time, so this function returns
+    the values rather than mutating an existing app instance.
+
+    Args:
+        config: Optional AuthConfig. If None, loads from environment variables.
+        auto_osm_routes: If True, include OSM OAuth routes. Default: True.
+
+    Returns:
+        Tuple of (dependencies dict, list of Router instances) to unpack
+        into the ``Litestar()`` constructor.
+
+    Example::
+
+        deps, route_handlers = setup_auth()
+        app = Litestar(route_handlers=route_handlers, dependencies=deps)
+    """
+    if config is None:
+        config = AuthConfig.from_env()
+
+    init_auth(config)
+    deps = create_dependencies()
+
+    route_handlers: list[Router] = []
+    if auto_osm_routes and config.osm_enabled:
+        route_handlers.append(osm_router)
+        logger.info("OSM OAuth routes included at /auth/osm/*")
+
+    logger.info(f"HOTOSM Auth initialized (Hanko: {config.hanko_api_url})")
+    return deps, route_handlers

--- a/auth-libs/python/tests/test_litestar_admin_routes.py
+++ b/auth-libs/python/tests/test_litestar_admin_routes.py
@@ -1,0 +1,160 @@
+"""Tests for Litestar admin routes with mocked database."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+litestar = pytest.importorskip("litestar")
+
+from litestar import Litestar
+from litestar.di import Provide
+from litestar.testing import TestClient
+
+from hotosm_auth.config import AuthConfig
+from hotosm_auth.models import HankoUser
+from hotosm_auth_litestar.admin_routes import create_admin_mappings_router
+from hotosm_auth_litestar.dependencies import init_auth
+
+
+def _make_config() -> AuthConfig:
+    return AuthConfig(
+        hanko_api_url="https://test.hanko.io",
+        cookie_secret="x" * 40,
+        cookie_domain=".test.local",
+        admin_emails="admin@example.com,super@example.com",
+    )
+
+
+def _make_admin_user() -> HankoUser:
+    now = datetime.now(timezone.utc)
+    return HankoUser(
+        id="admin-user-123",
+        email="admin@example.com",
+        email_verified=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_non_admin_user() -> HankoUser:
+    now = datetime.now(timezone.utc)
+    return HankoUser(
+        id="regular-user-456",
+        email="user@example.com",
+        email_verified=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class MockCursor:
+    """Mock async psycopg cursor."""
+
+    def __init__(self, fetchone_results=None, fetchall_results=None):
+        self.fetchone_results = list(fetchone_results or [])
+        self.fetchall_results = list(fetchall_results or [])
+        self.executed = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, query, params=None):
+        self.executed.append((str(query), params))
+
+    async def fetchone(self):
+        if self.fetchone_results:
+            return self.fetchone_results.pop(0)
+        return None
+
+    async def fetchall(self):
+        if self.fetchall_results:
+            return self.fetchall_results.pop(0)
+        return []
+
+
+class MockDB:
+    """Mock async psycopg connection."""
+
+    def __init__(self, cursor: MockCursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+def _build_app(current_user: HankoUser, cursor: MockCursor) -> Litestar:
+    async def get_db():
+        return MockDB(cursor)
+
+    admin_router = create_admin_mappings_router(get_db)
+    return Litestar(
+        route_handlers=[admin_router],
+        dependencies={
+            "current_user": Provide(lambda: current_user, sync_to_thread=False),
+        },
+    )
+
+
+class TestAdminRoutesAuthorization:
+    """Test admin route authorization."""
+
+    def test_non_admin_gets_403(self):
+        init_auth(_make_config())
+        app = _build_app(_make_non_admin_user(), MockCursor())
+
+        with TestClient(app=app) as client:
+            response = client.get("/admin/mappings")
+
+        assert response.status_code == 403
+        assert "Admin access required" in response.json()["detail"]
+
+    def test_admin_gets_access(self):
+        init_auth(_make_config())
+        cursor = MockCursor(fetchone_results=[(0,)], fetchall_results=[[]])
+        app = _build_app(_make_admin_user(), cursor)
+
+        with TestClient(app=app) as client:
+            response = client.get("/admin/mappings")
+
+        assert response.status_code == 200
+        assert response.json()["items"] == []
+
+
+class TestAdminRouteCrud:
+    """Test CRUD operations."""
+
+    def test_get_mapping_returns_404_when_not_found(self):
+        init_auth(_make_config())
+        cursor = MockCursor(fetchone_results=[None])
+        app = _build_app(_make_admin_user(), cursor)
+
+        with TestClient(app=app) as client:
+            response = client.get("/admin/mappings/missing-user")
+
+        assert response.status_code == 404
+
+    def test_create_mapping_returns_409_when_already_exists(self):
+        init_auth(_make_config())
+        cursor = MockCursor(fetchone_results=[(1,)])
+        app = _build_app(_make_admin_user(), cursor)
+
+        with TestClient(app=app) as client:
+            response = client.post(
+                "/admin/mappings",
+                json={"hanko_user_id": "existing-hanko", "app_user_id": "app-id"},
+            )
+
+        assert response.status_code == 409
+
+    def test_delete_mapping_returns_204_on_success(self):
+        init_auth(_make_config())
+        cursor = MockCursor(fetchone_results=[("hanko-123",)])
+        app = _build_app(_make_admin_user(), cursor)
+
+        with TestClient(app=app) as client:
+            response = client.delete("/admin/mappings/hanko-123")
+
+        assert response.status_code == 204

--- a/auth-libs/python/tests/test_litestar_dependencies.py
+++ b/auth-libs/python/tests/test_litestar_dependencies.py
@@ -1,0 +1,254 @@
+"""Tests for Litestar dependencies with mocked requests."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+litestar = pytest.importorskip("litestar")
+
+from hotosm_auth.config import AuthConfig
+from hotosm_auth.crypto import CookieCrypto
+from hotosm_auth.exceptions import TokenExpiredError, TokenInvalidError
+from hotosm_auth.models import HankoUser, OSMConnection
+from hotosm_auth_litestar.dependencies import (
+    clear_osm_cookie,
+    get_config,
+    get_cookie_crypto,
+    get_current_user,
+    get_current_user_optional,
+    get_jwt_validator,
+    get_osm_connection,
+    init_auth,
+    require_osm_connection,
+    set_osm_cookie,
+)
+
+
+def _make_config() -> AuthConfig:
+    return AuthConfig(
+        hanko_api_url="https://test.hanko.io",
+        cookie_secret="x" * 40,
+        cookie_domain=".test.local",
+        cookie_secure=True,
+        cookie_samesite="lax",
+    )
+
+
+def _make_user() -> HankoUser:
+    now = datetime.now(timezone.utc)
+    return HankoUser(
+        id="user-123",
+        email="test@example.com",
+        email_verified=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_osm_connection() -> OSMConnection:
+    return OSMConnection(
+        osm_user_id=12345,
+        osm_username="mapper",
+        osm_avatar_url=None,
+        access_token="token",
+        scopes=["read_prefs"],
+    )
+
+
+class TestInitAuth:
+    """Test auth initialization."""
+
+    def test_init_sets_globals(self):
+        config = _make_config()
+        init_auth(config)
+
+        assert get_config() == config
+        assert get_jwt_validator() is not None
+        assert get_cookie_crypto() is not None
+
+
+class TestGetCurrentUser:
+    """Test required user auth dependency."""
+
+    @pytest.mark.asyncio
+    async def test_returns_user_from_valid_token(self):
+        init_auth(_make_config())
+        validator = get_jwt_validator()
+        user = _make_user()
+
+        request = MagicMock()
+        request.headers = {}
+        request.cookies = {"hanko": "valid-jwt-token"}
+
+        with patch.object(
+            validator, "validate_token", new_callable=AsyncMock
+        ) as mock_validate:
+            mock_validate.return_value = user
+            result = await get_current_user(request)
+
+        assert result.id == "user-123"
+
+    @pytest.mark.asyncio
+    async def test_raises_401_when_no_token(self):
+        init_auth(_make_config())
+
+        request = MagicMock()
+        request.headers = {}
+        request.cookies = {}
+
+        with pytest.raises(Exception) as exc_info:
+            await get_current_user(request)
+
+        assert getattr(exc_info.value, "status_code", None) == 401
+
+    @pytest.mark.asyncio
+    async def test_raises_401_on_expired_token(self):
+        init_auth(_make_config())
+        validator = get_jwt_validator()
+
+        request = MagicMock()
+        request.headers = {}
+        request.cookies = {"hanko": "expired-token"}
+
+        with patch.object(
+            validator, "validate_token", new_callable=AsyncMock
+        ) as mock_validate:
+            mock_validate.side_effect = TokenExpiredError("Token expired")
+            with pytest.raises(Exception) as exc_info:
+                await get_current_user(request)
+
+        assert getattr(exc_info.value, "status_code", None) == 401
+
+    @pytest.mark.asyncio
+    async def test_raises_401_on_invalid_token(self):
+        init_auth(_make_config())
+        validator = get_jwt_validator()
+
+        request = MagicMock()
+        request.headers = {}
+        request.cookies = {"hanko": "bad-token"}
+
+        with patch.object(
+            validator, "validate_token", new_callable=AsyncMock
+        ) as mock_validate:
+            mock_validate.side_effect = TokenInvalidError("Invalid signature")
+            with pytest.raises(Exception) as exc_info:
+                await get_current_user(request)
+
+        assert getattr(exc_info.value, "status_code", None) == 401
+
+
+class TestGetCurrentUserOptional:
+    """Test optional user authentication."""
+
+    @pytest.mark.asyncio
+    async def test_returns_user_when_valid(self):
+        init_auth(_make_config())
+        validator = get_jwt_validator()
+        user = _make_user()
+
+        request = MagicMock()
+        request.headers = {}
+        request.cookies = {"hanko": "valid-token"}
+
+        with patch.object(
+            validator, "validate_token", new_callable=AsyncMock
+        ) as mock_validate:
+            mock_validate.return_value = user
+            result = await get_current_user_optional(request)
+
+        assert result is not None
+        assert result.id == "user-123"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_token(self):
+        init_auth(_make_config())
+
+        request = MagicMock()
+        request.headers = {}
+        request.cookies = {}
+
+        result = await get_current_user_optional(request)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_invalid_token(self):
+        init_auth(_make_config())
+        validator = get_jwt_validator()
+
+        request = MagicMock()
+        request.headers = {}
+        request.cookies = {"hanko": "bad-token"}
+
+        with patch.object(
+            validator, "validate_token", new_callable=AsyncMock
+        ) as mock_validate:
+            mock_validate.side_effect = TokenInvalidError("Bad token")
+            result = await get_current_user_optional(request)
+
+        assert result is None
+
+
+class TestOSMConnectionHelpers:
+    """Test OSM cookie helper dependencies."""
+
+    def test_get_osm_connection_returns_connection_from_valid_cookie(self):
+        config = _make_config()
+        init_auth(config)
+        crypto = get_cookie_crypto()
+
+        osm = _make_osm_connection()
+        encrypted = crypto.encrypt_osm_connection(osm)
+
+        request = MagicMock()
+        request.cookies = {"osm_connection": encrypted}
+
+        result = get_osm_connection(request)
+
+        assert result is not None
+        assert result.osm_user_id == 12345
+
+    def test_get_osm_connection_returns_none_when_missing(self):
+        init_auth(_make_config())
+
+        request = MagicMock()
+        request.cookies = {}
+
+        assert get_osm_connection(request) is None
+
+    def test_require_osm_connection_raises_403_when_missing(self):
+        with pytest.raises(Exception) as exc_info:
+            require_osm_connection(None)
+
+        assert getattr(exc_info.value, "status_code", None) == 403
+
+
+class TestCookieHelpers:
+    """Test cookie set/clear helpers."""
+
+    def test_sets_cookie_with_correct_attributes(self):
+        config = _make_config()
+        crypto = CookieCrypto(config.cookie_secret)
+        osm = _make_osm_connection()
+
+        response = MagicMock()
+        set_osm_cookie(response, osm, config, crypto)
+
+        response.set_cookie.assert_called_once()
+        call_kwargs = response.set_cookie.call_args.kwargs
+        assert call_kwargs["key"] == "osm_connection"
+        assert call_kwargs["httponly"] is True
+        assert call_kwargs["secure"] is True
+        assert call_kwargs["samesite"] == "lax"
+
+    def test_clears_cookie_with_multiple_combinations(self):
+        config = _make_config()
+        response = MagicMock()
+
+        clear_osm_cookie(response, config)
+
+        assert response.set_cookie.call_count > 1
+        for call in response.set_cookie.call_args_list:
+            assert call.kwargs["max_age"] == 0

--- a/auth-libs/python/tests/test_litestar_osm_routes.py
+++ b/auth-libs/python/tests/test_litestar_osm_routes.py
@@ -1,0 +1,262 @@
+"""Tests for Litestar OSM OAuth routes with mocked HTTP."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+litestar = pytest.importorskip("litestar")
+
+from litestar import Litestar
+from litestar.di import Provide
+from litestar.testing import TestClient
+
+from hotosm_auth.config import AuthConfig
+from hotosm_auth.exceptions import OSMOAuthError
+from hotosm_auth.models import HankoUser, OSMConnection
+from hotosm_auth_litestar.dependencies import init_auth
+from hotosm_auth_litestar.osm_routes import _oauth_states, osm_router
+
+
+def _make_config() -> AuthConfig:
+    return AuthConfig(
+        hanko_api_url="https://test.hanko.io",
+        cookie_secret="x" * 40,
+        cookie_domain=".test.local",
+        osm_enabled=True,
+        osm_client_id="test-client-id",
+        osm_client_secret="test-client-secret",
+        osm_redirect_uri="https://myapp.test/callback",
+        osm_scopes=["read_prefs"],
+    )
+
+
+def _make_config_osm_disabled() -> AuthConfig:
+    return AuthConfig(
+        hanko_api_url="https://test.hanko.io",
+        cookie_secret="x" * 40,
+        cookie_domain=".test.local",
+        osm_enabled=False,
+    )
+
+
+def _make_user() -> HankoUser:
+    now = datetime.now(timezone.utc)
+    return HankoUser(
+        id="user-123",
+        email="test@example.com",
+        email_verified=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_osm_connection() -> OSMConnection:
+    return OSMConnection(
+        osm_user_id=12345,
+        osm_username="mapper",
+        osm_avatar_url="https://osm.org/avatar.png",
+        access_token="access-token-123",
+        refresh_token="refresh-token-456",
+        scopes=["read_prefs"],
+    )
+
+
+def _build_app(
+    current_user: HankoUser, osm_connection: OSMConnection | None
+) -> Litestar:
+    return Litestar(
+        route_handlers=[osm_router],
+        dependencies={
+            "current_user": Provide(lambda: current_user, sync_to_thread=False),
+            "osm_connection": Provide(lambda: osm_connection, sync_to_thread=False),
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_oauth_states():
+    _oauth_states.clear()
+    yield
+    _oauth_states.clear()
+
+
+class TestOSMLogin:
+    """Test OSM login endpoint."""
+
+    def test_redirects_to_osm_authorization(self):
+        init_auth(_make_config())
+        app = _build_app(_make_user(), None)
+
+        with TestClient(app=app) as client:
+            response = client.get("/auth/osm/login", follow_redirects=False)
+
+        assert response.status_code in {302, 307}
+        location = response.headers["location"]
+        assert "openstreetmap.org/oauth2/authorize" in location
+        assert "client_id=test-client-id" in location
+        assert "state=" in location
+
+    def test_stores_oauth_state(self):
+        init_auth(_make_config())
+        app = _build_app(_make_user(), None)
+
+        with TestClient(app=app) as client:
+            client.get("/auth/osm/login", follow_redirects=False)
+
+        assert len(_oauth_states) == 1
+        state_data = list(_oauth_states.values())[0]
+        assert state_data["user_id"] == "user-123"
+
+    def test_returns_400_when_osm_disabled(self):
+        init_auth(_make_config_osm_disabled())
+        app = _build_app(_make_user(), None)
+
+        with TestClient(app=app) as client:
+            response = client.get("/auth/osm/login")
+
+        assert response.status_code == 400
+        assert "not enabled" in response.json()["detail"]
+
+
+class TestOSMCallback:
+    """Test OSM callback endpoint."""
+
+    def test_exchanges_code_and_redirects(self):
+        config = _make_config()
+        init_auth(config)
+        user = _make_user()
+        app = _build_app(user, None)
+
+        _oauth_states["valid-state"] = {
+            "user_id": user.id,
+            "redirect_url": "/dashboard",
+        }
+
+        osm_conn = _make_osm_connection()
+        with patch(
+            "hotosm_auth_litestar.osm_routes.OSMOAuthClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.exchange_code = AsyncMock(return_value=osm_conn)
+            mock_client_class.return_value = mock_client
+
+            with TestClient(app=app) as client:
+                response = client.get(
+                    "/auth/osm/callback?code=auth-code&state=valid-state",
+                    follow_redirects=False,
+                )
+
+        assert response.status_code == 303
+        assert response.headers["location"] == "/dashboard"
+        mock_client.exchange_code.assert_called_once_with("auth-code")
+
+    def test_returns_400_for_invalid_state(self):
+        init_auth(_make_config())
+        app = _build_app(_make_user(), None)
+
+        with TestClient(app=app) as client:
+            response = client.get(
+                "/auth/osm/callback?code=auth-code&state=invalid-state"
+            )
+
+        assert response.status_code == 400
+        assert "Invalid OAuth state" in response.json()["detail"]
+
+    def test_returns_400_for_mismatched_user(self):
+        init_auth(_make_config())
+        app = _build_app(_make_user(), None)
+
+        _oauth_states["valid-state"] = {"user_id": "other-user", "redirect_url": "/"}
+
+        with TestClient(app=app) as client:
+            response = client.get("/auth/osm/callback?code=auth-code&state=valid-state")
+
+        assert response.status_code == 400
+        assert "Invalid OAuth state" in response.json()["detail"]
+
+    def test_returns_400_on_oauth_error(self):
+        init_auth(_make_config())
+        user = _make_user()
+        app = _build_app(user, None)
+
+        _oauth_states["valid-state"] = {"user_id": user.id, "redirect_url": "/"}
+
+        with patch(
+            "hotosm_auth_litestar.osm_routes.OSMOAuthClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.exchange_code = AsyncMock(
+                side_effect=OSMOAuthError("Token exchange failed")
+            )
+            mock_client_class.return_value = mock_client
+
+            with TestClient(app=app) as client:
+                response = client.get(
+                    "/auth/osm/callback?code=bad-code&state=valid-state"
+                )
+
+        assert response.status_code == 400
+        assert "OSM OAuth failed" in response.json()["detail"]
+
+
+class TestOSMStatus:
+    """Test OSM status endpoint."""
+
+    def test_returns_connected_true_with_connection(self):
+        init_auth(_make_config())
+        app = _build_app(_make_user(), _make_osm_connection())
+
+        with TestClient(app=app) as client:
+            response = client.get("/auth/osm/status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["connected"] is True
+        assert data["osm_user_id"] == 12345
+
+    def test_returns_connected_false_without_connection(self):
+        init_auth(_make_config())
+        app = _build_app(_make_user(), None)
+
+        with TestClient(app=app) as client:
+            response = client.get("/auth/osm/status")
+
+        assert response.status_code == 200
+        assert response.json()["connected"] is False
+
+
+class TestOSMDisconnect:
+    """Test OSM disconnect endpoint."""
+
+    def test_revokes_tokens_and_clears_cookie(self):
+        init_auth(_make_config())
+        app = _build_app(_make_user(), _make_osm_connection())
+
+        with patch(
+            "hotosm_auth_litestar.osm_routes.OSMOAuthClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.revoke_token = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            with TestClient(app=app) as client:
+                response = client.post("/auth/osm/disconnect")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "disconnected"
+        assert data["tokens_revoked"] is True
+        assert mock_client.revoke_token.call_count == 2
+
+    def test_clears_cookie_even_without_connection(self):
+        init_auth(_make_config())
+        app = _build_app(_make_user(), None)
+
+        with TestClient(app=app) as client:
+            response = client.post("/auth/osm/disconnect")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "disconnected"
+        assert data["tokens_revoked"] is False

--- a/auth-libs/python/tests/test_litestar_setup.py
+++ b/auth-libs/python/tests/test_litestar_setup.py
@@ -1,0 +1,84 @@
+"""Tests for Litestar setup and auth contexts."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+litestar = pytest.importorskip("litestar")
+
+from hotosm_auth.config import AuthConfig
+from hotosm_auth.models import HankoUser, OSMConnection
+from hotosm_auth_litestar.dependencies import AuthContext
+from hotosm_auth_litestar.setup import setup_auth
+
+
+def _make_user() -> HankoUser:
+    now = datetime.now(timezone.utc)
+    return HankoUser(
+        id="user-123",
+        email="test@example.com",
+        email_verified=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_osm_connection() -> OSMConnection:
+    return OSMConnection(
+        osm_user_id=12345,
+        osm_username="mapper",
+        osm_avatar_url=None,
+        access_token="token",
+        scopes=["read_prefs"],
+    )
+
+
+class TestAuthContext:
+    """Test the Litestar auth context wrapper."""
+
+    def test_require_osm_returns_connection_when_present(self):
+        context = AuthContext(user=_make_user(), osm=_make_osm_connection())
+
+        result = context.require_osm()
+
+        assert result.osm_user_id == 12345
+
+    def test_require_osm_raises_403_when_missing(self):
+        context = AuthContext(user=_make_user(), osm=None)
+
+        with pytest.raises(Exception) as exc_info:
+            context.require_osm()
+
+        assert getattr(exc_info.value, "status_code", None) == 403
+
+
+class TestSetupAuth:
+    """Test Litestar setup helper."""
+
+    def test_setup_auth_returns_dependencies_and_routes_with_osm_enabled(self):
+        config = AuthConfig(
+            hanko_api_url="https://test.hanko.io",
+            cookie_secret="x" * 40,
+            osm_enabled=True,
+            osm_client_id="id",
+            osm_client_secret="secret",
+            osm_redirect_uri="https://app.test/auth/osm/callback",
+        )
+
+        deps, route_handlers = setup_auth(config=config)
+
+        assert "current_user" in deps
+        assert "auth" in deps
+        assert len(route_handlers) == 1
+
+    def test_setup_auth_skips_osm_routes_when_disabled(self):
+        config = AuthConfig(
+            hanko_api_url="https://test.hanko.io",
+            cookie_secret="x" * 40,
+            osm_enabled=False,
+        )
+
+        deps, route_handlers = setup_auth(config=config)
+
+        assert "current_user" in deps
+        assert route_handlers == []

--- a/auth-libs/python/uv.lock
+++ b/auth-libs/python/uv.lock
@@ -439,6 +439,18 @@ wheels = [
 ]
 
 [[package]]
+name = "faker"
+version = "40.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/03/14428edc541467c460d363f6e94bee9acc271f3e62470630fc9a647d0cf2/faker-40.8.0.tar.gz", hash = "sha256:936a3c9be6c004433f20aa4d99095df5dec82b8c7ad07459756041f8c1728875", size = 1956493, upload-time = "2026-03-04T16:18:48.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/3b/c6348f1e285e75b069085b18110a4e6325b763a5d35d5e204356fc7c20b3/faker-40.8.0-py3-none-any.whl", hash = "sha256:eb21bdba18f7a8375382eb94fb436fce07046893dc94cb20817d28deb0c3d579", size = 1989124, upload-time = "2026-03-04T16:18:46.45Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.128.0"
 source = { registry = "https://pypi.org/simple" }
@@ -462,7 +474,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/32/6a/33d1702184d94106d3cdd7bfb788e19723206fce152e303473ca3b946c7b/greenlet-3.3.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:6f8496d434d5cb2dce025773ba5597f71f5410ae499d5dd9533e0653258cdb3d", size = 273658, upload-time = "2025-12-04T14:23:37.494Z" },
     { url = "https://files.pythonhosted.org/packages/d6/b7/2b5805bbf1907c26e434f4e448cd8b696a0b71725204fa21a211ff0c04a7/greenlet-3.3.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b96dc7eef78fd404e022e165ec55327f935b9b52ff355b067eb4a0267fc1cffb", size = 574810, upload-time = "2025-12-04T14:50:04.154Z" },
     { url = "https://files.pythonhosted.org/packages/94/38/343242ec12eddf3d8458c73f555c084359883d4ddc674240d9e61ec51fd6/greenlet-3.3.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:73631cd5cccbcfe63e3f9492aaa664d278fda0ce5c3d43aeda8e77317e38efbd", size = 586248, upload-time = "2025-12-04T14:57:39.35Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d0/0ae86792fb212e4384041e0ef8e7bc66f59a54912ce407d26a966ed2914d/greenlet-3.3.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b299a0cb979f5d7197442dccc3aee67fce53500cd88951b7e6c35575701c980b", size = 597403, upload-time = "2025-12-04T15:07:10.831Z" },
     { url = "https://files.pythonhosted.org/packages/b6/a8/15d0aa26c0036a15d2659175af00954aaaa5d0d66ba538345bd88013b4d7/greenlet-3.3.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dee147740789a4632cace364816046e43310b59ff8fb79833ab043aefa72fd5", size = 586910, upload-time = "2025-12-04T14:25:59.705Z" },
     { url = "https://files.pythonhosted.org/packages/e1/9b/68d5e3b7ccaba3907e5532cf8b9bf16f9ef5056a008f195a367db0ff32db/greenlet-3.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:39b28e339fc3c348427560494e28d8a6f3561c8d2bcf7d706e1c624ed8d822b9", size = 1547206, upload-time = "2025-12-04T15:04:21.027Z" },
     { url = "https://files.pythonhosted.org/packages/66/bd/e3086ccedc61e49f91e2cfb5ffad9d8d62e5dc85e512a6200f096875b60c/greenlet-3.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b3c374782c2935cc63b2a27ba8708471de4ad1abaa862ffdb1ef45a643ddbb7d", size = 1613359, upload-time = "2025-12-04T14:27:26.548Z" },
@@ -470,7 +481,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/cb/48e964c452ca2b92175a9b2dca037a553036cb053ba69e284650ce755f13/greenlet-3.3.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e29f3018580e8412d6aaf5641bb7745d38c85228dacf51a73bd4e26ddf2a6a8e", size = 274908, upload-time = "2025-12-04T14:23:26.435Z" },
     { url = "https://files.pythonhosted.org/packages/28/da/38d7bff4d0277b594ec557f479d65272a893f1f2a716cad91efeb8680953/greenlet-3.3.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a687205fb22794e838f947e2194c0566d3812966b41c78709554aa883183fb62", size = 577113, upload-time = "2025-12-04T14:50:05.493Z" },
     { url = "https://files.pythonhosted.org/packages/3c/f2/89c5eb0faddc3ff014f1c04467d67dee0d1d334ab81fadbf3744847f8a8a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4243050a88ba61842186cb9e63c7dfa677ec146160b0efd73b855a3d9c7fcf32", size = 590338, upload-time = "2025-12-04T14:57:41.136Z" },
-    { url = "https://files.pythonhosted.org/packages/80/d7/db0a5085035d05134f8c089643da2b44cc9b80647c39e93129c5ef170d8f/greenlet-3.3.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:670d0f94cd302d81796e37299bcd04b95d62403883b24225c6b5271466612f45", size = 601098, upload-time = "2025-12-04T15:07:11.898Z" },
     { url = "https://files.pythonhosted.org/packages/dc/a6/e959a127b630a58e23529972dbc868c107f9d583b5a9f878fb858c46bc1a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cb3a8ec3db4a3b0eb8a3c25436c2d49e3505821802074969db017b87bc6a948", size = 590206, upload-time = "2025-12-04T14:26:01.254Z" },
     { url = "https://files.pythonhosted.org/packages/48/60/29035719feb91798693023608447283b266b12efc576ed013dd9442364bb/greenlet-3.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2de5a0b09eab81fc6a382791b995b1ccf2b172a9fec934747a7a23d2ff291794", size = 1550668, upload-time = "2025-12-04T15:04:22.439Z" },
     { url = "https://files.pythonhosted.org/packages/0a/5f/783a23754b691bfa86bd72c3033aa107490deac9b2ef190837b860996c9f/greenlet-3.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4449a736606bd30f27f8e1ff4678ee193bc47f6ca810d705981cfffd6ce0d8c5", size = 1615483, upload-time = "2025-12-04T14:27:28.083Z" },
@@ -478,7 +488,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/0a/a3871375c7b9727edaeeea994bfff7c63ff7804c9829c19309ba2e058807/greenlet-3.3.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b01548f6e0b9e9784a2c99c5651e5dc89ffcbe870bc5fb2e5ef864e9cc6b5dcb", size = 276379, upload-time = "2025-12-04T14:23:30.498Z" },
     { url = "https://files.pythonhosted.org/packages/43/ab/7ebfe34dce8b87be0d11dae91acbf76f7b8246bf9d6b319c741f99fa59c6/greenlet-3.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349345b770dc88f81506c6861d22a6ccd422207829d2c854ae2af8025af303e3", size = 597294, upload-time = "2025-12-04T14:50:06.847Z" },
     { url = "https://files.pythonhosted.org/packages/a4/39/f1c8da50024feecd0793dbd5e08f526809b8ab5609224a2da40aad3a7641/greenlet-3.3.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8e18ed6995e9e2c0b4ed264d2cf89260ab3ac7e13555b8032b25a74c6d18655", size = 607742, upload-time = "2025-12-04T14:57:42.349Z" },
-    { url = "https://files.pythonhosted.org/packages/77/cb/43692bcd5f7a0da6ec0ec6d58ee7cddb606d055ce94a62ac9b1aa481e969/greenlet-3.3.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c024b1e5696626890038e34f76140ed1daf858e37496d33f2af57f06189e70d7", size = 622297, upload-time = "2025-12-04T15:07:13.552Z" },
     { url = "https://files.pythonhosted.org/packages/75/b0/6bde0b1011a60782108c01de5913c588cf51a839174538d266de15e4bf4d/greenlet-3.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:047ab3df20ede6a57c35c14bf5200fcf04039d50f908270d3f9a7a82064f543b", size = 609885, upload-time = "2025-12-04T14:26:02.368Z" },
     { url = "https://files.pythonhosted.org/packages/49/0e/49b46ac39f931f59f987b7cd9f34bfec8ef81d2a1e6e00682f55be5de9f4/greenlet-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2d9ad37fc657b1102ec880e637cccf20191581f75c64087a549e66c57e1ceb53", size = 1567424, upload-time = "2025-12-04T15:04:23.757Z" },
     { url = "https://files.pythonhosted.org/packages/05/f5/49a9ac2dff7f10091935def9165c90236d8f175afb27cbed38fb1d61ab6b/greenlet-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83cd0e36932e0e7f36a64b732a6f60c2fc2df28c351bae79fbaf4f8092fe7614", size = 1636017, upload-time = "2025-12-04T14:27:29.688Z" },
@@ -486,7 +495,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/2f/28592176381b9ab2cafa12829ba7b472d177f3acc35d8fbcf3673d966fff/greenlet-3.3.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:a1e41a81c7e2825822f4e068c48cb2196002362619e2d70b148f20a831c00739", size = 275140, upload-time = "2025-12-04T14:23:01.282Z" },
     { url = "https://files.pythonhosted.org/packages/2c/80/fbe937bf81e9fca98c981fe499e59a3f45df2a04da0baa5c2be0dca0d329/greenlet-3.3.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f515a47d02da4d30caaa85b69474cec77b7929b2e936ff7fb853d42f4bf8808", size = 599219, upload-time = "2025-12-04T14:50:08.309Z" },
     { url = "https://files.pythonhosted.org/packages/c2/ff/7c985128f0514271b8268476af89aee6866df5eec04ac17dcfbc676213df/greenlet-3.3.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d2d9fd66bfadf230b385fdc90426fcd6eb64db54b40c495b72ac0feb5766c54", size = 610211, upload-time = "2025-12-04T14:57:43.968Z" },
-    { url = "https://files.pythonhosted.org/packages/79/07/c47a82d881319ec18a4510bb30463ed6891f2ad2c1901ed5ec23d3de351f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30a6e28487a790417d036088b3bcb3f3ac7d8babaa7d0139edbaddebf3af9492", size = 624311, upload-time = "2025-12-04T15:07:14.697Z" },
     { url = "https://files.pythonhosted.org/packages/fd/8e/424b8c6e78bd9837d14ff7df01a9829fc883ba2ab4ea787d4f848435f23f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:087ea5e004437321508a8d6f20efc4cfec5e3c30118e1417ea96ed1d93950527", size = 612833, upload-time = "2025-12-04T14:26:03.669Z" },
     { url = "https://files.pythonhosted.org/packages/b5/ba/56699ff9b7c76ca12f1cdc27a886d0f81f2189c3455ff9f65246780f713d/greenlet-3.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab97cf74045343f6c60a39913fa59710e4bd26a536ce7ab2397adf8b27e67c39", size = 1567256, upload-time = "2025-12-04T15:04:25.276Z" },
     { url = "https://files.pythonhosted.org/packages/1e/37/f31136132967982d698c71a281a8901daf1a8fbab935dce7c0cf15f942cc/greenlet-3.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5375d2e23184629112ca1ea89a53389dddbffcf417dad40125713d88eb5f96e8", size = 1636483, upload-time = "2025-12-04T14:27:30.804Z" },
@@ -494,7 +502,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/7c/f0a6d0ede2c7bf092d00bc83ad5bafb7e6ec9b4aab2fbdfa6f134dc73327/greenlet-3.3.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:60c2ef0f578afb3c8d92ea07ad327f9a062547137afe91f38408f08aacab667f", size = 275671, upload-time = "2025-12-04T14:23:05.267Z" },
     { url = "https://files.pythonhosted.org/packages/44/06/dac639ae1a50f5969d82d2e3dd9767d30d6dbdbab0e1a54010c8fe90263c/greenlet-3.3.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a5d554d0712ba1de0a6c94c640f7aeba3f85b3a6e1f2899c11c2c0428da9365", size = 646360, upload-time = "2025-12-04T14:50:10.026Z" },
     { url = "https://files.pythonhosted.org/packages/e0/94/0fb76fe6c5369fba9bf98529ada6f4c3a1adf19e406a47332245ef0eb357/greenlet-3.3.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3a898b1e9c5f7307ebbde4102908e6cbfcb9ea16284a3abe15cab996bee8b9b3", size = 658160, upload-time = "2025-12-04T14:57:45.41Z" },
-    { url = "https://files.pythonhosted.org/packages/93/79/d2c70cae6e823fac36c3bbc9077962105052b7ef81db2f01ec3b9bf17e2b/greenlet-3.3.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dcd2bdbd444ff340e8d6bdf54d2f206ccddbb3ccfdcd3c25bf4afaa7b8f0cf45", size = 671388, upload-time = "2025-12-04T15:07:15.789Z" },
     { url = "https://files.pythonhosted.org/packages/b8/14/bab308fc2c1b5228c3224ec2bf928ce2e4d21d8046c161e44a2012b5203e/greenlet-3.3.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5773edda4dc00e173820722711d043799d3adb4f01731f40619e07ea2750b955", size = 660166, upload-time = "2025-12-04T14:26:05.099Z" },
     { url = "https://files.pythonhosted.org/packages/4b/d2/91465d39164eaa0085177f61983d80ffe746c5a1860f009811d498e7259c/greenlet-3.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac0549373982b36d5fd5d30beb8a7a33ee541ff98d2b502714a09f1169f31b55", size = 1615193, upload-time = "2025-12-04T15:04:27.041Z" },
     { url = "https://files.pythonhosted.org/packages/42/1b/83d110a37044b92423084d52d5d5a3b3a73cafb51b547e6d7366ff62eff1/greenlet-3.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d198d2d977460358c3b3a4dc844f875d1adb33817f0613f663a656f463764ccc", size = 1683653, upload-time = "2025-12-04T14:27:32.366Z" },
@@ -502,7 +509,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/66/bd6317bc5932accf351fc19f177ffba53712a202f9df10587da8df257c7e/greenlet-3.3.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d6ed6f85fae6cdfdb9ce04c9bf7a08d666cfcfb914e7d006f44f840b46741931", size = 282638, upload-time = "2025-12-04T14:25:20.941Z" },
     { url = "https://files.pythonhosted.org/packages/30/cf/cc81cb030b40e738d6e69502ccbd0dd1bced0588e958f9e757945de24404/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9125050fcf24554e69c4cacb086b87b3b55dc395a8b3ebe6487b045b2614388", size = 651145, upload-time = "2025-12-04T14:50:11.039Z" },
     { url = "https://files.pythonhosted.org/packages/9c/ea/1020037b5ecfe95ca7df8d8549959baceb8186031da83d5ecceff8b08cd2/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:87e63ccfa13c0a0f6234ed0add552af24cc67dd886731f2261e46e241608bee3", size = 654236, upload-time = "2025-12-04T14:57:47.007Z" },
-    { url = "https://files.pythonhosted.org/packages/69/cc/1e4bae2e45ca2fa55299f4e85854606a78ecc37fead20d69322f96000504/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2662433acbca297c9153a4023fe2161c8dcfdcc91f10433171cf7e7d94ba2221", size = 662506, upload-time = "2025-12-04T15:07:16.906Z" },
     { url = "https://files.pythonhosted.org/packages/57/b9/f8025d71a6085c441a7eaff0fd928bbb275a6633773667023d19179fe815/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c6e9b9c1527a78520357de498b0e709fb9e2f49c3a513afd5a249007261911b", size = 653783, upload-time = "2025-12-04T14:26:06.225Z" },
     { url = "https://files.pythonhosted.org/packages/f6/c7/876a8c7a7485d5d6b5c6821201d542ef28be645aa024cfe1145b35c120c1/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:286d093f95ec98fdd92fcb955003b8a3d054b4e2cab3e2707a5039e7b50520fd", size = 1614857, upload-time = "2025-12-04T15:04:28.484Z" },
     { url = "https://files.pythonhosted.org/packages/4f/dc/041be1dff9f23dac5f48a43323cd0789cb798342011c19a248d9c9335536/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c10513330af5b8ae16f023e8ddbfb486ab355d04467c4679c5cfe4659975dd9", size = 1676034, upload-time = "2025-12-04T14:27:33.531Z" },
@@ -533,6 +539,7 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "mypy" },
+    { name = "psycopg" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -547,6 +554,10 @@ fastapi = [
     { name = "fastapi" },
     { name = "sqlalchemy" },
 ]
+litestar = [
+    { name = "litestar" },
+    { name = "psycopg" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -556,7 +567,10 @@ requires-dist = [
     { name = "djangorestframework", marker = "extra == 'django'", specifier = ">=3.14.0" },
     { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.104.0" },
     { name = "httpx", specifier = ">=0.25.0" },
+    { name = "litestar", marker = "extra == 'litestar'", specifier = ">=2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
+    { name = "psycopg", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "psycopg", marker = "extra == 'litestar'", specifier = ">=3.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
@@ -566,7 +580,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "sqlalchemy", marker = "extra == 'fastapi'", specifier = ">=2.0.0" },
 ]
-provides-extras = ["fastapi", "django", "dev"]
+provides-extras = ["fastapi", "django", "litestar", "dev"]
 
 [[package]]
 name = "httpcore"
@@ -688,6 +702,264 @@ wheels = [
 ]
 
 [[package]]
+name = "litestar"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "click" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "httpx" },
+    { name = "litestar-htmx" },
+    { name = "msgspec" },
+    { name = "multidict" },
+    { name = "multipart" },
+    { name = "polyfactory" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "rich-click" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/96/86dd853ea6b3570e699515b24e8476e00f554e9038f48d3bc84eb4d55429/litestar-2.21.0.tar.gz", hash = "sha256:3bde5e97ae9054db83d0fb8738c57871be5257e3a4a27d8109f914302681ec02", size = 375390, upload-time = "2026-02-14T15:16:10.049Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/e9/35bc58351570bd08e134fb53c93e5d88558c4bc31ce6568574bbb60dca42/litestar-2.21.0-py3-none-any.whl", hash = "sha256:b8bd76cb7f4b6585f3bb9b952a42e5a8bfbf0256d52bf2cfb9b4fe7fd5534a35", size = 567574, upload-time = "2026-02-14T15:16:07.718Z" },
+]
+
+[[package]]
+name = "litestar-htmx"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/b9/7e296aa1adada25cce8e5f89a996b0e38d852d93b1b656a2058226c542a2/litestar_htmx-0.5.0.tar.gz", hash = "sha256:e02d1a3a92172c874835fa3e6749d65ae9fc626d0df46719490a16293e2146fb", size = 119755, upload-time = "2025-06-11T21:19:45.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/24/8d99982f0aa9c1cd82073c6232b54a0dbe6797c7d63c0583a6c68ee3ddf2/litestar_htmx-0.5.0-py3-none-any.whl", hash = "sha256:92833aa47e0d0e868d2a7dbfab75261f124f4b83d4f9ad12b57b9a68f86c50e6", size = 9970, upload-time = "2025-06-11T21:19:44.465Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "msgspec"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/9c/bfbd12955a49180cbd234c5d29ec6f74fe641698f0cd9df154a854fc8a15/msgspec-0.20.0.tar.gz", hash = "sha256:692349e588fde322875f8d3025ac01689fead5901e7fb18d6870a44519d62a29", size = 317862, upload-time = "2025-11-24T03:56:28.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/5e/151883ba2047cca9db8ed2f86186b054ad200bc231352df15b0c1dd75b1f/msgspec-0.20.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:23a6ec2a3b5038c233b04740a545856a068bc5cb8db184ff493a58e08c994fbf", size = 195191, upload-time = "2025-11-24T03:55:08.549Z" },
+    { url = "https://files.pythonhosted.org/packages/50/88/a795647672f547c983eff0823b82aaa35db922c767e1b3693e2dcf96678d/msgspec-0.20.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cde2c41ed3eaaef6146365cb0d69580078a19f974c6cb8165cc5dcd5734f573e", size = 188513, upload-time = "2025-11-24T03:55:10.008Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/91/eb0abb0e0de142066cebfe546dc9140c5972ea824aa6ff507ad0b6a126ac/msgspec-0.20.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5da0daa782f95d364f0d95962faed01e218732aa1aa6cad56b25a5d2092e75a4", size = 216370, upload-time = "2025-11-24T03:55:11.566Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2a/48e41d9ef0a24b1c6e67cbd94a676799e0561bfbc163be1aaaff5ca853f5/msgspec-0.20.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9369d5266144bef91be2940a3821e03e51a93c9080fde3ef72728c3f0a3a8bb7", size = 222653, upload-time = "2025-11-24T03:55:13.159Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c9/14b825df203d980f82a623450d5f39e7f7a09e6e256c52b498ea8f29d923/msgspec-0.20.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:90fb865b306ca92c03964a5f3d0cd9eb1adda14f7e5ac7943efd159719ea9f10", size = 222337, upload-time = "2025-11-24T03:55:14.777Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d7/39a5c3ddd294f587d6fb8efccc8361b6aa5089974015054071e665c9d24b/msgspec-0.20.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e8112cd48b67dfc0cfa49fc812b6ce7eb37499e1d95b9575061683f3428975d3", size = 225565, upload-time = "2025-11-24T03:55:16.4Z" },
+    { url = "https://files.pythonhosted.org/packages/98/bd/5db3c14d675ee12842afb9b70c94c64f2c873f31198c46cbfcd7dffafab0/msgspec-0.20.0-cp310-cp310-win_amd64.whl", hash = "sha256:666b966d503df5dc27287675f525a56b6e66a2b8e8ccd2877b0c01328f19ae6c", size = 188412, upload-time = "2025-11-24T03:55:17.747Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c7/06cc218bc0c86f0c6c6f34f7eeea6cfb8b835070e8031e3b0ef00f6c7c69/msgspec-0.20.0-cp310-cp310-win_arm64.whl", hash = "sha256:099e3e85cd5b238f2669621be65f0728169b8c7cb7ab07f6137b02dc7feea781", size = 173951, upload-time = "2025-11-24T03:55:19.335Z" },
+    { url = "https://files.pythonhosted.org/packages/03/59/fdcb3af72f750a8de2bcf39d62ada70b5eb17b06d7f63860e0a679cb656b/msgspec-0.20.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:09e0efbf1ac641fedb1d5496c59507c2f0dc62a052189ee62c763e0aae217520", size = 193345, upload-time = "2025-11-24T03:55:20.613Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/15/3c225610da9f02505d37d69a77f4a2e7daae2a125f99d638df211ba84e59/msgspec-0.20.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:23ee3787142e48f5ee746b2909ce1b76e2949fbe0f97f9f6e70879f06c218b54", size = 186867, upload-time = "2025-11-24T03:55:22.4Z" },
+    { url = "https://files.pythonhosted.org/packages/81/36/13ab0c547e283bf172f45491edfdea0e2cecb26ae61e3a7b1ae6058b326d/msgspec-0.20.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:81f4ac6f0363407ac0465eff5c7d4d18f26870e00674f8fcb336d898a1e36854", size = 215351, upload-time = "2025-11-24T03:55:23.958Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/96/5c095b940de3aa6b43a71ec76275ac3537b21bd45c7499b5a17a429110fa/msgspec-0.20.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb4d873f24ae18cd1334f4e37a178ed46c9d186437733351267e0a269bdf7e53", size = 219896, upload-time = "2025-11-24T03:55:25.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7a/81a7b5f01af300761087b114dafa20fb97aed7184d33aab64d48874eb187/msgspec-0.20.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b92b8334427b8393b520c24ff53b70f326f79acf5f74adb94fd361bcff8a1d4e", size = 220389, upload-time = "2025-11-24T03:55:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c0/3d0cce27db9a9912421273d49eab79ce01ecd2fed1a2f1b74af9b445f33c/msgspec-0.20.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:562c44b047c05cc0384e006fae7a5e715740215c799429e0d7e3e5adf324285a", size = 223348, upload-time = "2025-11-24T03:55:28.311Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5e/406b7d578926b68790e390d83a1165a9bfc2d95612a1a9c1c4d5c72ea815/msgspec-0.20.0-cp311-cp311-win_amd64.whl", hash = "sha256:d1dcc93a3ce3d3195985bfff18a48274d0b5ffbc96fa1c5b89da6f0d9af81b29", size = 188713, upload-time = "2025-11-24T03:55:29.553Z" },
+    { url = "https://files.pythonhosted.org/packages/47/87/14fe2316624ceedf76a9e94d714d194cbcb699720b210ff189f89ca4efd7/msgspec-0.20.0-cp311-cp311-win_arm64.whl", hash = "sha256:aa387aa330d2e4bd69995f66ea8fdc87099ddeedf6fdb232993c6a67711e7520", size = 174229, upload-time = "2025-11-24T03:55:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/6f/1e25eee957e58e3afb2a44b94fa95e06cebc4c236193ed0de3012fff1e19/msgspec-0.20.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2aba22e2e302e9231e85edc24f27ba1f524d43c223ef5765bd8624c7df9ec0a5", size = 196391, upload-time = "2025-11-24T03:55:32.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ee/af51d090ada641d4b264992a486435ba3ef5b5634bc27e6eb002f71cef7d/msgspec-0.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:716284f898ab2547fedd72a93bb940375de9fbfe77538f05779632dc34afdfde", size = 188644, upload-time = "2025-11-24T03:55:33.934Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d6/9709ee093b7742362c2934bfb1bbe791a1e09bed3ea5d8a18ce552fbfd73/msgspec-0.20.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:558ed73315efa51b1538fa8f1d3b22c8c5ff6d9a2a62eff87d25829b94fc5054", size = 218852, upload-time = "2025-11-24T03:55:35.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a2/488517a43ccf5a4b6b6eca6dd4ede0bd82b043d1539dd6bb908a19f8efd3/msgspec-0.20.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:509ac1362a1d53aa66798c9b9fd76872d7faa30fcf89b2fba3bcbfd559d56eb0", size = 224937, upload-time = "2025-11-24T03:55:36.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/49b832808aa23b85d4f090d1d2e48a4e3834871415031ed7c5fe48723156/msgspec-0.20.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1353c2c93423602e7dea1aa4c92f3391fdfc25ff40e0bacf81d34dbc68adb870", size = 222858, upload-time = "2025-11-24T03:55:38.187Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/56/1dc2fa53685dca9c3f243a6cbecd34e856858354e455b77f47ebd76cf5bf/msgspec-0.20.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:cb33b5eb5adb3c33d749684471c6a165468395d7aa02d8867c15103b81e1da3e", size = 227248, upload-time = "2025-11-24T03:55:39.496Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/51/aba940212c23b32eedce752896205912c2668472ed5b205fc33da28a6509/msgspec-0.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:fb1d934e435dd3a2b8cf4bbf47a8757100b4a1cfdc2afdf227541199885cdacb", size = 190024, upload-time = "2025-11-24T03:55:40.829Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/3b9f259d94f183daa9764fef33fdc7010f7ecffc29af977044fa47440a83/msgspec-0.20.0-cp312-cp312-win_arm64.whl", hash = "sha256:00648b1e19cf01b2be45444ba9dc961bd4c056ffb15706651e64e5d6ec6197b7", size = 175390, upload-time = "2025-11-24T03:55:42.05Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/d1/b902d38b6e5ba3bdddbec469bba388d647f960aeed7b5b3623a8debe8a76/msgspec-0.20.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9c1ff8db03be7598b50dd4b4a478d6fe93faae3bd54f4f17aa004d0e46c14c46", size = 196463, upload-time = "2025-11-24T03:55:43.405Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b6/eff0305961a1d9447ec2b02f8c73c8946f22564d302a504185b730c9a761/msgspec-0.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f6532369ece217fd37c5ebcfd7e981f2615628c21121b7b2df9d3adcf2fd69b8", size = 188650, upload-time = "2025-11-24T03:55:44.761Z" },
+    { url = "https://files.pythonhosted.org/packages/99/93/f2ec1ae1de51d3fdee998a1ede6b2c089453a2ee82b5c1b361ed9095064a/msgspec-0.20.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9a1697da2f85a751ac3cc6a97fceb8e937fc670947183fb2268edaf4016d1ee", size = 218834, upload-time = "2025-11-24T03:55:46.441Z" },
+    { url = "https://files.pythonhosted.org/packages/28/83/36557b04cfdc317ed8a525c4993b23e43a8fbcddaddd78619112ca07138c/msgspec-0.20.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7fac7e9c92eddcd24c19d9e5f6249760941485dff97802461ae7c995a2450111", size = 224917, upload-time = "2025-11-24T03:55:48.06Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/56/362037a1ed5be0b88aced59272442c4b40065c659700f4b195a7f4d0ac88/msgspec-0.20.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f953a66f2a3eb8d5ea64768445e2bb301d97609db052628c3e1bcb7d87192a9f", size = 222821, upload-time = "2025-11-24T03:55:49.388Z" },
+    { url = "https://files.pythonhosted.org/packages/92/75/fa2370ec341cedf663731ab7042e177b3742645c5dd4f64dc96bd9f18a6b/msgspec-0.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:247af0313ae64a066d3aea7ba98840f6681ccbf5c90ba9c7d17f3e39dbba679c", size = 227227, upload-time = "2025-11-24T03:55:51.125Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/25/5e8080fe0117f799b1b68008dc29a65862077296b92550632de015128579/msgspec-0.20.0-cp313-cp313-win_amd64.whl", hash = "sha256:67d5e4dfad52832017018d30a462604c80561aa62a9d548fc2bd4e430b66a352", size = 189966, upload-time = "2025-11-24T03:55:52.458Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b6/63363422153937d40e1cb349c5081338401f8529a5a4e216865decd981bf/msgspec-0.20.0-cp313-cp313-win_arm64.whl", hash = "sha256:91a52578226708b63a9a13de287b1ec3ed1123e4a088b198143860c087770458", size = 175378, upload-time = "2025-11-24T03:55:53.721Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/18/62dc13ab0260c7d741dda8dc7f481495b93ac9168cd887dda5929880eef8/msgspec-0.20.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:eead16538db1b3f7ec6e3ed1f6f7c5dec67e90f76e76b610e1ffb5671815633a", size = 196407, upload-time = "2025-11-24T03:55:55.001Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1d/b9949e4ad6953e9f9a142c7997b2f7390c81e03e93570c7c33caf65d27e1/msgspec-0.20.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:703c3bb47bf47801627fb1438f106adbfa2998fe586696d1324586a375fca238", size = 188889, upload-time = "2025-11-24T03:55:56.311Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/19/f8bb2dc0f1bfe46cc7d2b6b61c5e9b5a46c62298e8f4d03bbe499c926180/msgspec-0.20.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6cdb227dc585fb109305cee0fd304c2896f02af93ecf50a9c84ee54ee67dbb42", size = 219691, upload-time = "2025-11-24T03:55:57.908Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8e/6b17e43f6eb9369d9858ee32c97959fcd515628a1df376af96c11606cf70/msgspec-0.20.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27d35044dd8818ac1bd0fedb2feb4fbdff4e3508dd7c5d14316a12a2d96a0de0", size = 224918, upload-time = "2025-11-24T03:55:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/db/0e833a177db1a4484797adba7f429d4242585980b90882cc38709e1b62df/msgspec-0.20.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b4296393a29ee42dd25947981c65506fd4ad39beaf816f614146fa0c5a6c91ae", size = 223436, upload-time = "2025-11-24T03:56:00.716Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/30/d2ee787f4c918fd2b123441d49a7707ae9015e0e8e1ab51aa7967a97b90e/msgspec-0.20.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:205fbdadd0d8d861d71c8f3399fe1a82a2caf4467bc8ff9a626df34c12176980", size = 227190, upload-time = "2025-11-24T03:56:02.371Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/37/9c4b58ff11d890d788e700b827db2366f4d11b3313bf136780da7017278b/msgspec-0.20.0-cp314-cp314-win_amd64.whl", hash = "sha256:7dfebc94fe7d3feec6bc6c9df4f7e9eccc1160bb5b811fbf3e3a56899e398a6b", size = 193950, upload-time = "2025-11-24T03:56:03.668Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/4e/cab707bf2fa57408e2934e5197fc3560079db34a1e3cd2675ff2e47e07de/msgspec-0.20.0-cp314-cp314-win_arm64.whl", hash = "sha256:2ad6ae36e4a602b24b4bf4eaf8ab5a441fec03e1f1b5931beca8ebda68f53fc0", size = 179018, upload-time = "2025-11-24T03:56:05.038Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/06/3da3fc9aaa55618a8f43eb9052453cfe01f82930bca3af8cea63a89f3a11/msgspec-0.20.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f84703e0e6ef025663dd1de828ca028774797b8155e070e795c548f76dde65d5", size = 200389, upload-time = "2025-11-24T03:56:06.375Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3b/cc4270a5ceab40dfe1d1745856951b0a24fd16ac8539a66ed3004a60c91e/msgspec-0.20.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7c83fc24dd09cf1275934ff300e3951b3adc5573f0657a643515cc16c7dee131", size = 193198, upload-time = "2025-11-24T03:56:07.742Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ae/4c7905ac53830c8e3c06fdd60e3cdcfedc0bbc993872d1549b84ea21a1bd/msgspec-0.20.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f13ccb1c335a124e80c4562573b9b90f01ea9521a1a87f7576c2e281d547f56", size = 225973, upload-time = "2025-11-24T03:56:09.18Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/da/032abac1de4d0678d99eaeadb1323bd9d247f4711c012404ba77ed6f15ca/msgspec-0.20.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17c2b5ca19f19306fc83c96d85e606d2cc107e0caeea85066b5389f664e04846", size = 229509, upload-time = "2025-11-24T03:56:10.898Z" },
+    { url = "https://files.pythonhosted.org/packages/69/52/fdc7bdb7057a166f309e0b44929e584319e625aaba4771b60912a9321ccd/msgspec-0.20.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d931709355edabf66c2dd1a756b2d658593e79882bc81aae5964969d5a291b63", size = 230434, upload-time = "2025-11-24T03:56:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/fe/1dfd5f512b26b53043884e4f34710c73e294e7cc54278c3fe28380e42c37/msgspec-0.20.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:565f915d2e540e8a0c93a01ff67f50aebe1f7e22798c6a25873f9fda8d1325f8", size = 231758, upload-time = "2025-11-24T03:56:13.765Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f6/9ba7121b8e0c4e0beee49575d1dbc804e2e72467692f0428cf39ceba1ea5/msgspec-0.20.0-cp314-cp314t-win_amd64.whl", hash = "sha256:726f3e6c3c323f283f6021ebb6c8ccf58d7cd7baa67b93d73bfbe9a15c34ab8d", size = 206540, upload-time = "2025-11-24T03:56:15.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/3e/c5187de84bb2c2ca334ab163fcacf19a23ebb1d876c837f81a1b324a15bf/msgspec-0.20.0-cp314-cp314t-win_arm64.whl", hash = "sha256:93f23528edc51d9f686808a361728e903d6f2be55c901d6f5c92e44c6d546bfc", size = 183011, upload-time = "2025-11-24T03:56:16.442Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/0b/19348d4c98980c4851d2f943f8ebafdece2ae7ef737adcfa5994ce8e5f10/multidict-6.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c93c3db7ea657dd4637d57e74ab73de31bccefe144d3d4ce370052035bc85fb5", size = 77176, upload-time = "2026-01-26T02:42:59.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/9de3f8077852e3d438215c81e9b691244532d2e05b4270e89ce67b7d103c/multidict-6.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:974e72a2474600827abaeda71af0c53d9ebbc3c2eb7da37b37d7829ae31232d8", size = 44996, upload-time = "2026-01-26T02:43:01.674Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5c/08c7f7fe311f32e83f7621cd3f99d805f45519cd06fafb247628b861da7d/multidict-6.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cdea2e7b2456cfb6694fb113066fd0ec7ea4d67e3a35e1f4cbeea0b448bf5872", size = 44631, upload-time = "2026-01-26T02:43:03.169Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7f/0e3b1390ae772f27501199996b94b52ceeb64fe6f9120a32c6c3f6b781be/multidict-6.7.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17207077e29342fdc2c9a82e4b306f1127bf1ea91f8b71e02d4798a70bb99991", size = 242561, upload-time = "2026-01-26T02:43:04.733Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/f4/8719f4f167586af317b69dd3e90f913416c91ca610cac79a45c53f590312/multidict-6.7.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4f49cb5661344764e4c7c7973e92a47a59b8fc19b6523649ec9dc4960e58a03", size = 242223, upload-time = "2026-01-26T02:43:06.695Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ab/7c36164cce64a6ad19c6d9a85377b7178ecf3b89f8fd589c73381a5eedfd/multidict-6.7.1-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a9fc4caa29e2e6ae408d1c450ac8bf19892c5fca83ee634ecd88a53332c59981", size = 222322, upload-time = "2026-01-26T02:43:08.472Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/79/a25add6fb38035b5337bc5734f296d9afc99163403bbcf56d4170f97eb62/multidict-6.7.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c5f0c21549ab432b57dcc82130f388d84ad8179824cc3f223d5e7cfbfd4143f6", size = 254005, upload-time = "2026-01-26T02:43:10.127Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/7b/64a87cf98e12f756fc8bd444b001232ffff2be37288f018ad0d3f0aae931/multidict-6.7.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7dfb78d966b2c906ae1d28ccf6e6712a3cd04407ee5088cd276fe8cb42186190", size = 251173, upload-time = "2026-01-26T02:43:11.731Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ac/b605473de2bb404e742f2cc3583d12aedb2352a70e49ae8fce455b50c5aa/multidict-6.7.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b0d9b91d1aa44db9c1f1ecd0d9d2ae610b2f4f856448664e01a3b35899f3f92", size = 243273, upload-time = "2026-01-26T02:43:13.063Z" },
+    { url = "https://files.pythonhosted.org/packages/03/65/11492d6a0e259783720f3bc1d9ea55579a76f1407e31ed44045c99542004/multidict-6.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dd96c01a9dcd4889dcfcf9eb5544ca0c77603f239e3ffab0524ec17aea9a93ee", size = 238956, upload-time = "2026-01-26T02:43:14.843Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a7/7ee591302af64e7c196fb63fe856c788993c1372df765102bd0448e7e165/multidict-6.7.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:067343c68cd6612d375710f895337b3a98a033c94f14b9a99eff902f205424e2", size = 233477, upload-time = "2026-01-26T02:43:16.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/99/c109962d58756c35fd9992fed7f2355303846ea2ff054bb5f5e9d6b888de/multidict-6.7.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5884a04f4ff56c6120f6ccf703bdeb8b5079d808ba604d4d53aec0d55dc33568", size = 243615, upload-time = "2026-01-26T02:43:17.84Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5f/1973e7c771c86e93dcfe1c9cc55a5481b610f6614acfc28c0d326fe6bfad/multidict-6.7.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8affcf1c98b82bc901702eb73b6947a1bfa170823c153fe8a47b5f5f02e48e40", size = 249930, upload-time = "2026-01-26T02:43:19.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a5/f170fc2268c3243853580203378cd522446b2df632061e0a5409817854c7/multidict-6.7.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:0d17522c37d03e85c8098ec8431636309b2682cf12e58f4dbc76121fb50e4962", size = 243807, upload-time = "2026-01-26T02:43:20.286Z" },
+    { url = "https://files.pythonhosted.org/packages/de/01/73856fab6d125e5bc652c3986b90e8699a95e84b48d72f39ade6c0e74a8c/multidict-6.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:24c0cf81544ca5e17cfcb6e482e7a82cd475925242b308b890c9452a074d4505", size = 239103, upload-time = "2026-01-26T02:43:21.508Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/46/f1220bd9944d8aa40d8ccff100eeeee19b505b857b6f603d6078cb5315b0/multidict-6.7.1-cp310-cp310-win32.whl", hash = "sha256:d82dd730a95e6643802f4454b8fdecdf08667881a9c5670db85bc5a56693f122", size = 41416, upload-time = "2026-01-26T02:43:22.703Z" },
+    { url = "https://files.pythonhosted.org/packages/68/00/9b38e272a770303692fc406c36e1a4c740f401522d5787691eb38a8925a8/multidict-6.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:cf37cbe5ced48d417ba045aca1b21bafca67489452debcde94778a576666a1df", size = 46022, upload-time = "2026-01-26T02:43:23.77Z" },
+    { url = "https://files.pythonhosted.org/packages/64/65/d8d42490c02ee07b6bbe00f7190d70bb4738b3cce7629aaf9f213ef730dd/multidict-6.7.1-cp310-cp310-win_arm64.whl", hash = "sha256:59bc83d3f66b41dac1e7460aac1d196edc70c9ba3094965c467715a70ecb46db", size = 43238, upload-time = "2026-01-26T02:43:24.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f1/a90635c4f88fb913fbf4ce660b83b7445b7a02615bda034b2f8eb38fd597/multidict-6.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ff981b266af91d7b4b3793ca3382e53229088d193a85dfad6f5f4c27fc73e5d", size = 76626, upload-time = "2026-01-26T02:43:26.485Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/267e64eaf6fc637a15b35f5de31a566634a2740f97d8d094a69d34f524a4/multidict-6.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:844c5bca0b5444adb44a623fb0a1310c2f4cd41f402126bb269cd44c9b3f3e1e", size = 44706, upload-time = "2026-01-26T02:43:27.607Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a4/d45caf2b97b035c57267791ecfaafbd59c68212004b3842830954bb4b02e/multidict-6.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f2a0a924d4c2e9afcd7ec64f9de35fcd96915149b2216e1cb2c10a56df483855", size = 44356, upload-time = "2026-01-26T02:43:28.661Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d2/0a36c8473f0cbaeadd5db6c8b72d15bbceeec275807772bfcd059bef487d/multidict-6.7.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8be1802715a8e892c784c0197c2ace276ea52702a0ede98b6310c8f255a5afb3", size = 244355, upload-time = "2026-01-26T02:43:31.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/16/8c65be997fd7dd311b7d39c7b6e71a0cb449bad093761481eccbbe4b42a2/multidict-6.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e2d2ed645ea29f31c4c7ea1552fcfd7cb7ba656e1eafd4134a6620c9f5fdd9e", size = 246433, upload-time = "2026-01-26T02:43:32.581Z" },
+    { url = "https://files.pythonhosted.org/packages/01/fb/4dbd7e848d2799c6a026ec88ad39cf2b8416aa167fcc903baa55ecaa045c/multidict-6.7.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:95922cee9a778659e91db6497596435777bd25ed116701a4c034f8e46544955a", size = 225376, upload-time = "2026-01-26T02:43:34.417Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8a/4a3a6341eac3830f6053062f8fbc9a9e54407c80755b3f05bc427295c2d0/multidict-6.7.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6b83cabdc375ffaaa15edd97eb7c0c672ad788e2687004990074d7d6c9b140c8", size = 257365, upload-time = "2026-01-26T02:43:35.741Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a2/dd575a69c1aa206e12d27d0770cdf9b92434b48a9ef0cd0d1afdecaa93c4/multidict-6.7.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:38fb49540705369bab8484db0689d86c0a33a0a9f2c1b197f506b71b4b6c19b0", size = 254747, upload-time = "2026-01-26T02:43:36.976Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/56/21b27c560c13822ed93133f08aa6372c53a8e067f11fbed37b4adcdac922/multidict-6.7.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:439cbebd499f92e9aa6793016a8acaa161dfa749ae86d20960189f5398a19144", size = 246293, upload-time = "2026-01-26T02:43:38.258Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/23466059dc3854763423d0ad6c0f3683a379d97673b1b89ec33826e46728/multidict-6.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d3bc717b6fe763b8be3f2bee2701d3c8eb1b2a8ae9f60910f1b2860c82b6c49", size = 242962, upload-time = "2026-01-26T02:43:40.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/67/51dd754a3524d685958001e8fa20a0f5f90a6a856e0a9dcabff69be3dbb7/multidict-6.7.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:619e5a1ac57986dbfec9f0b301d865dddf763696435e2962f6d9cf2fdff2bb71", size = 237360, upload-time = "2026-01-26T02:43:41.752Z" },
+    { url = "https://files.pythonhosted.org/packages/64/3f/036dfc8c174934d4b55d86ff4f978e558b0e585cef70cfc1ad01adc6bf18/multidict-6.7.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0b38ebffd9be37c1170d33bc0f36f4f262e0a09bc1aac1c34c7aa51a7293f0b3", size = 245940, upload-time = "2026-01-26T02:43:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/20/6214d3c105928ebc353a1c644a6ef1408bc5794fcb4f170bb524a3c16311/multidict-6.7.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:10ae39c9cfe6adedcdb764f5e8411d4a92b055e35573a2eaa88d3323289ef93c", size = 253502, upload-time = "2026-01-26T02:43:44.371Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/c653bc4ae1be70a0f836b82172d643fcf1dade042ba2676ab08ec08bff0f/multidict-6.7.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:25167cc263257660290fba06b9318d2026e3c910be240a146e1f66dd114af2b0", size = 247065, upload-time = "2026-01-26T02:43:45.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/11/a854b4154cd3bd8b1fd375e8a8ca9d73be37610c361543d56f764109509b/multidict-6.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:128441d052254f42989ef98b7b6a6ecb1e6f708aa962c7984235316db59f50fa", size = 241870, upload-time = "2026-01-26T02:43:47.054Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bf/9676c0392309b5fdae322333d22a829715b570edb9baa8016a517b55b558/multidict-6.7.1-cp311-cp311-win32.whl", hash = "sha256:d62b7f64ffde3b99d06b707a280db04fb3855b55f5a06df387236051d0668f4a", size = 41302, upload-time = "2026-01-26T02:43:48.753Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/68/f16a3a8ba6f7b6dc92a1f19669c0810bd2c43fc5a02da13b1cbf8e253845/multidict-6.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:bdbf9f3b332abd0cdb306e7c2113818ab1e922dc84b8f8fd06ec89ed2a19ab8b", size = 45981, upload-time = "2026-01-26T02:43:49.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/9dd5305253fa00cd3c7555dbef69d5bf4133debc53b87ab8d6a44d411665/multidict-6.7.1-cp311-cp311-win_arm64.whl", hash = "sha256:b8c990b037d2fff2f4e33d3f21b9b531c5745b33a49a7d6dbe7a177266af44f6", size = 43159, upload-time = "2026-01-26T02:43:51.635Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cf/18ef143a81610136d3da8193da9d80bfe1cb548a1e2d1c775f26b23d024a/multidict-6.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fccb473e87eaa1382689053e4a4618e7ba7b9b9b8d6adf2027ee474597128cd", size = 45456, upload-time = "2026-01-26T02:43:53.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0fa96985700739c4c7853a43c0b3e169360d6855780021bfc6d0f1ce7c123e7", size = 43872, upload-time = "2026-01-26T02:43:55.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3b/d6bd75dc4f3ff7c73766e04e705b00ed6dbbaccf670d9e05a12b006f5a21/multidict-6.7.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb2a55f408c3043e42b40cc8eecd575afa27b7e0b956dfb190de0f8499a57a53", size = 251018, upload-time = "2026-01-26T02:43:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75", size = 258883, upload-time = "2026-01-26T02:43:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/7ed40adafea3d4f1c8b916e3b5cc3a8e07dfcdcb9cd72800f4ed3ca1b387/multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b", size = 242413, upload-time = "2026-01-26T02:43:58.755Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/57/b8565ff533e48595503c785f8361ff9a4fde4d67de25c207cd0ba3befd03/multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733", size = 268404, upload-time = "2026-01-26T02:44:00.216Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/50/9810c5c29350f7258180dfdcb2e52783a0632862eb334c4896ac717cebcb/multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a", size = 269456, upload-time = "2026-01-26T02:44:02.202Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961", size = 256322, upload-time = "2026-01-26T02:44:03.56Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582", size = 253955, upload-time = "2026-01-26T02:44:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4c/7c672c8aad41534ba619bcd4ade7a0dc87ed6b8b5c06149b85d3dd03f0cd/multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e", size = 251254, upload-time = "2026-01-26T02:44:06.133Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bd/84c24de512cbafbdbc39439f74e967f19570ce7924e3007174a29c348916/multidict-6.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c102791b1c4f3ab36ce4101154549105a53dc828f016356b3e3bcae2e3a039d3", size = 252059, upload-time = "2026-01-26T02:44:07.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/f5449385510825b73d01c2d4087bf6d2fccc20a2d42ac34df93191d3dd03/multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6", size = 263588, upload-time = "2026-01-26T02:44:09.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/11/afc7c677f68f75c84a69fe37184f0f82fce13ce4b92f49f3db280b7e92b3/multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a", size = 259642, upload-time = "2026-01-26T02:44:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba", size = 251377, upload-time = "2026-01-26T02:44:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a4/840f5b97339e27846c46307f2530a2805d9d537d8b8bd416af031cad7fa0/multidict-6.7.1-cp312-cp312-win32.whl", hash = "sha256:28ca5ce2fd9716631133d0e9a9b9a745ad7f60bac2bccafb56aa380fc0b6c511", size = 41887, upload-time = "2026-01-26T02:44:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19", size = 46053, upload-time = "2026-01-26T02:44:15.371Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5b/aba28e4ee4006ae4c7df8d327d31025d760ffa992ea23812a601d226e682/multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf", size = 43307, upload-time = "2026-01-26T02:44:16.852Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/22/929c141d6c0dba87d3e1d38fbdf1ba8baba86b7776469f2bc2d3227a1e67/multidict-6.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2b41f5fed0ed563624f1c17630cb9941cf2309d4df00e494b551b5f3e3d67a23", size = 76174, upload-time = "2026-01-26T02:44:18.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/75/bc704ae15fee974f8fccd871305e254754167dce5f9e42d88a2def741a1d/multidict-6.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84e61e3af5463c19b67ced91f6c634effb89ef8bfc5ca0267f954451ed4bb6a2", size = 45116, upload-time = "2026-01-26T02:44:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/79/76/55cd7186f498ed080a18440c9013011eb548f77ae1b297206d030eb1180a/multidict-6.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:935434b9853c7c112eee7ac891bc4cb86455aa631269ae35442cb316790c1445", size = 43524, upload-time = "2026-01-26T02:44:21.571Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/3c/414842ef8d5a1628d68edee29ba0e5bcf235dbfb3ccd3ea303a7fe8c72ff/multidict-6.7.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:432feb25a1cb67fe82a9680b4d65fb542e4635cb3166cd9c01560651ad60f177", size = 249368, upload-time = "2026-01-26T02:44:22.803Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/32/befed7f74c458b4a525e60519fe8d87eef72bb1e99924fa2b0f9d97a221e/multidict-6.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e82d14e3c948952a1a85503817e038cba5905a3352de76b9a465075d072fba23", size = 256952, upload-time = "2026-01-26T02:44:24.306Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d6/c878a44ba877f366630c860fdf74bfb203c33778f12b6ac274936853c451/multidict-6.7.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4cfb48c6ea66c83bcaaf7e4dfa7ec1b6bbcf751b7db85a328902796dfde4c060", size = 240317, upload-time = "2026-01-26T02:44:25.772Z" },
+    { url = "https://files.pythonhosted.org/packages/68/49/57421b4d7ad2e9e60e25922b08ceb37e077b90444bde6ead629095327a6f/multidict-6.7.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1d540e51b7e8e170174555edecddbd5538105443754539193e3e1061864d444d", size = 267132, upload-time = "2026-01-26T02:44:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/fe/ec0edd52ddbcea2a2e89e174f0206444a61440b40f39704e64dc807a70bd/multidict-6.7.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:273d23f4b40f3dce4d6c8a821c741a86dec62cded82e1175ba3d99be128147ed", size = 268140, upload-time = "2026-01-26T02:44:29.588Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/73/6e1b01cbeb458807aa0831742232dbdd1fa92bfa33f52a3f176b4ff3dc11/multidict-6.7.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d624335fd4fa1c08a53f8b4be7676ebde19cd092b3895c421045ca87895b429", size = 254277, upload-time = "2026-01-26T02:44:30.902Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b2/5fb8c124d7561a4974c342bc8c778b471ebbeb3cc17df696f034a7e9afe7/multidict-6.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:12fad252f8b267cc75b66e8fc51b3079604e8d43a75428ffe193cd9e2195dfd6", size = 252291, upload-time = "2026-01-26T02:44:32.31Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/96/51d4e4e06bcce92577fcd488e22600bd38e4fd59c20cb49434d054903bd2/multidict-6.7.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:03ede2a6ffbe8ef936b92cb4529f27f42be7f56afcdab5ab739cd5f27fb1cbf9", size = 250156, upload-time = "2026-01-26T02:44:33.734Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6b/420e173eec5fba721a50e2a9f89eda89d9c98fded1124f8d5c675f7a0c0f/multidict-6.7.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:90efbcf47dbe33dcf643a1e400d67d59abeac5db07dc3f27d6bdeae497a2198c", size = 249742, upload-time = "2026-01-26T02:44:35.222Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a3/ec5b5bd98f306bc2aa297b8c6f11a46714a56b1e6ef5ebda50a4f5d7c5fb/multidict-6.7.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c4b9bfc148f5a91be9244d6264c53035c8a0dcd2f51f1c3c6e30e30ebaa1c84", size = 262221, upload-time = "2026-01-26T02:44:36.604Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f7/e8c0d0da0cd1e28d10e624604e1a36bcc3353aaebdfdc3a43c72bc683a12/multidict-6.7.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:401c5a650f3add2472d1d288c26deebc540f99e2fb83e9525007a74cd2116f1d", size = 258664, upload-time = "2026-01-26T02:44:38.008Z" },
+    { url = "https://files.pythonhosted.org/packages/52/da/151a44e8016dd33feed44f730bd856a66257c1ee7aed4f44b649fb7edeb3/multidict-6.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:97891f3b1b3ffbded884e2916cacf3c6fc87b66bb0dde46f7357404750559f33", size = 249490, upload-time = "2026-01-26T02:44:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/87/af/a3b86bf9630b732897f6fc3f4c4714b90aa4361983ccbdcd6c0339b21b0c/multidict-6.7.1-cp313-cp313-win32.whl", hash = "sha256:e1c5988359516095535c4301af38d8a8838534158f649c05dd1050222321bcb3", size = 41695, upload-time = "2026-01-26T02:44:41.318Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/35/e994121b0e90e46134673422dd564623f93304614f5d11886b1b3e06f503/multidict-6.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:960c83bf01a95b12b08fd54324a4eb1d5b52c88932b5cba5d6e712bb3ed12eb5", size = 45884, upload-time = "2026-01-26T02:44:42.488Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/61/42d3e5dbf661242a69c97ea363f2d7b46c567da8eadef8890022be6e2ab0/multidict-6.7.1-cp313-cp313-win_arm64.whl", hash = "sha256:563fe25c678aaba333d5399408f5ec3c383ca5b663e7f774dd179a520b8144df", size = 43122, upload-time = "2026-01-26T02:44:43.664Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b3/e6b21c6c4f314bb956016b0b3ef2162590a529b84cb831c257519e7fde44/multidict-6.7.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c76c4bec1538375dad9d452d246ca5368ad6e1c9039dadcf007ae59c70619ea1", size = 83175, upload-time = "2026-01-26T02:44:44.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/76/23ecd2abfe0957b234f6c960f4ade497f55f2c16aeb684d4ecdbf1c95791/multidict-6.7.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:57b46b24b5d5ebcc978da4ec23a819a9402b4228b8a90d9c656422b4bdd8a963", size = 48460, upload-time = "2026-01-26T02:44:46.106Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/57/a0ed92b23f3a042c36bc4227b72b97eca803f5f1801c1ab77c8a212d455e/multidict-6.7.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e954b24433c768ce78ab7929e84ccf3422e46deb45a4dc9f93438f8217fa2d34", size = 46930, upload-time = "2026-01-26T02:44:47.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/66/02ec7ace29162e447f6382c495dc95826bf931d3818799bbef11e8f7df1a/multidict-6.7.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3bd231490fa7217cc832528e1cd8752a96f0125ddd2b5749390f7c3ec8721b65", size = 242582, upload-time = "2026-01-26T02:44:48.604Z" },
+    { url = "https://files.pythonhosted.org/packages/58/18/64f5a795e7677670e872673aca234162514696274597b3708b2c0d276cce/multidict-6.7.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:253282d70d67885a15c8a7716f3a73edf2d635793ceda8173b9ecc21f2fb8292", size = 250031, upload-time = "2026-01-26T02:44:50.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ed/e192291dbbe51a8290c5686f482084d31bcd9d09af24f63358c3d42fd284/multidict-6.7.1-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0b4c48648d7649c9335cf1927a8b87fa692de3dcb15faa676c6a6f1f1aabda43", size = 228596, upload-time = "2026-01-26T02:44:51.951Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/7e/3562a15a60cf747397e7f2180b0a11dc0c38d9175a650e75fa1b4d325e15/multidict-6.7.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:98bc624954ec4d2c7cb074b8eefc2b5d0ce7d482e410df446414355d158fe4ca", size = 257492, upload-time = "2026-01-26T02:44:53.902Z" },
+    { url = "https://files.pythonhosted.org/packages/24/02/7d0f9eae92b5249bb50ac1595b295f10e263dd0078ebb55115c31e0eaccd/multidict-6.7.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1b99af4d9eec0b49927b4402bcbb58dea89d3e0db8806a4086117019939ad3dd", size = 255899, upload-time = "2026-01-26T02:44:55.316Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/9b60ed9e23e64c73a5cde95269ef1330678e9c6e34dd4eb6b431b85b5a10/multidict-6.7.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6aac4f16b472d5b7dc6f66a0d49dd57b0e0902090be16594dc9ebfd3d17c47e7", size = 247970, upload-time = "2026-01-26T02:44:56.783Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/06/538e58a63ed5cfb0bd4517e346b91da32fde409d839720f664e9a4ae4f9d/multidict-6.7.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:21f830fe223215dffd51f538e78c172ed7c7f60c9b96a2bf05c4848ad49921c3", size = 245060, upload-time = "2026-01-26T02:44:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2f/d743a3045a97c895d401e9bd29aaa09b94f5cbdf1bd561609e5a6c431c70/multidict-6.7.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:f5dd81c45b05518b9aa4da4aa74e1c93d715efa234fd3e8a179df611cc85e5f4", size = 235888, upload-time = "2026-01-26T02:44:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/38/83/5a325cac191ab28b63c52f14f1131f3b0a55ba3b9aa65a6d0bf2a9b921a0/multidict-6.7.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:eb304767bca2bb92fb9c5bd33cedc95baee5bb5f6c88e63706533a1c06ad08c8", size = 243554, upload-time = "2026-01-26T02:45:01.054Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/9d2327086bd15da2725ef6aae624208e2ef828ed99892b17f60c344e57ed/multidict-6.7.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c9035dde0f916702850ef66460bc4239d89d08df4d02023a5926e7446724212c", size = 252341, upload-time = "2026-01-26T02:45:02.484Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/2c/2a1aa0280cf579d0f6eed8ee5211c4f1730bd7e06c636ba2ee6aafda302e/multidict-6.7.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:af959b9beeb66c822380f222f0e0a1889331597e81f1ded7f374f3ecb0fd6c52", size = 246391, upload-time = "2026-01-26T02:45:03.862Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/03/7ca022ffc36c5a3f6e03b179a5ceb829be9da5783e6fe395f347c0794680/multidict-6.7.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:41f2952231456154ee479651491e94118229844dd7226541788be783be2b5108", size = 243422, upload-time = "2026-01-26T02:45:05.296Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/1d/b31650eab6c5778aceed46ba735bd97f7c7d2f54b319fa916c0f96e7805b/multidict-6.7.1-cp313-cp313t-win32.whl", hash = "sha256:df9f19c28adcb40b6aae30bbaa1478c389efd50c28d541d76760199fc1037c32", size = 47770, upload-time = "2026-01-26T02:45:06.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/2d2d1d522e51285bd61b1e20df8f47ae1a9d80839db0b24ea783b3832832/multidict-6.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d54ecf9f301853f2c5e802da559604b3e95bb7a3b01a9c295c6ee591b9882de8", size = 53109, upload-time = "2026-01-26T02:45:08.044Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a3/cc409ba012c83ca024a308516703cf339bdc4b696195644a7215a5164a24/multidict-6.7.1-cp313-cp313t-win_arm64.whl", hash = "sha256:5a37ca18e360377cfda1d62f5f382ff41f2b8c4ccb329ed974cc2e1643440118", size = 45573, upload-time = "2026-01-26T02:45:09.349Z" },
+    { url = "https://files.pythonhosted.org/packages/91/cc/db74228a8be41884a567e88a62fd589a913708fcf180d029898c17a9a371/multidict-6.7.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8f333ec9c5eb1b7105e3b84b53141e66ca05a19a605368c55450b6ba208cb9ee", size = 75190, upload-time = "2026-01-26T02:45:10.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a407f13c188f804c759fc6a9f88286a565c242a76b27626594c133b82883b5c2", size = 44486, upload-time = "2026-01-26T02:45:11.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0e161ddf326db5577c3a4cc2d8648f81456e8a20d40415541587a71620d7a7d1", size = 43219, upload-time = "2026-01-26T02:45:14.346Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bb/2c0c2287963f4259c85e8bcbba9182ced8d7fca65c780c38e99e61629d11/multidict-6.7.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1e3a8bb24342a8201d178c3b4984c26ba81a577c80d4d525727427460a50c22d", size = 245132, upload-time = "2026-01-26T02:45:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97231140a50f5d447d3164f994b86a0bed7cd016e2682f8650d6a9158e14fd31", size = 252420, upload-time = "2026-01-26T02:45:17.293Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/78f7275e73fa17b24c9a51b0bd9d73ba64bb32d0ed51b02a746eb876abe7/multidict-6.7.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b10359683bd8806a200fd2909e7c8ca3a7b24ec1d8132e483d58e791d881048", size = 233510, upload-time = "2026-01-26T02:45:19.356Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/8167187f62ae3cbd52da7893f58cb036b47ea3fb67138787c76800158982/multidict-6.7.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:283ddac99f7ac25a4acadbf004cb5ae34480bbeb063520f70ce397b281859362", size = 264094, upload-time = "2026-01-26T02:45:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e7/69a3a83b7b030cf283fb06ce074a05a02322359783424d7edf0f15fe5022/multidict-6.7.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:538cec1e18c067d0e6103aa9a74f9e832904c957adc260e61cd9d8cf0c3b3d37", size = 260786, upload-time = "2026-01-26T02:45:22.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7eee46ccb30ff48a1e35bb818cc90846c6be2b68240e42a78599166722cea709", size = 248483, upload-time = "2026-01-26T02:45:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/d5a99e3acbca0e29c5d9cba8f92ceb15dce78bab963b308ae692981e3a5d/multidict-6.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa263a02f4f2dd2d11a7b1bb4362aa7cb1049f84a9235d31adf63f30143469a0", size = 248403, upload-time = "2026-01-26T02:45:25.982Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/e58cd31f6c7d5102f2a4bf89f96b9cf7e00b6c6f3d04ecc44417c00a5a3c/multidict-6.7.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2e1425e2f99ec5bd36c15a01b690a1a2456209c5deed58f95469ffb46039ccbb", size = 240315, upload-time = "2026-01-26T02:45:27.487Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/1cd210229559cb90b6786c30676bb0c58249ff42f942765f88793b41fdce/multidict-6.7.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:497394b3239fc6f0e13a78a3e1b61296e72bf1c5f94b4c4eb80b265c37a131cd", size = 245528, upload-time = "2026-01-26T02:45:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f2/6e1107d226278c876c783056b7db43d800bb64c6131cec9c8dfb6903698e/multidict-6.7.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:233b398c29d3f1b9676b4b6f75c518a06fcb2ea0b925119fb2c1bc35c05e1601", size = 258784, upload-time = "2026-01-26T02:45:30.503Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c1/11f664f14d525e4a1b5327a82d4de61a1db604ab34c6603bb3c2cc63ad34/multidict-6.7.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:93b1818e4a6e0930454f0f2af7dfce69307ca03cdcfb3739bf4d91241967b6c1", size = 251980, upload-time = "2026-01-26T02:45:32.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9f/75a9ac888121d0c5bbd4ecf4eead45668b1766f6baabfb3b7f66a410e231/multidict-6.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f33dc2a3abe9249ea5d8360f969ec7f4142e7ac45ee7014d8f8d5acddf178b7b", size = 243602, upload-time = "2026-01-26T02:45:34.043Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e7/50bf7b004cc8525d80dbbbedfdc7aed3e4c323810890be4413e589074032/multidict-6.7.1-cp314-cp314-win32.whl", hash = "sha256:3ab8b9d8b75aef9df299595d5388b14530839f6422333357af1339443cff777d", size = 40930, upload-time = "2026-01-26T02:45:36.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:5e01429a929600e7dab7b166062d9bb54a5eed752384c7384c968c2afab8f50f", size = 45074, upload-time = "2026-01-26T02:45:37.546Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ab/22803b03285fa3a525f48217963da3a65ae40f6a1b6f6cf2768879e208f9/multidict-6.7.1-cp314-cp314-win_arm64.whl", hash = "sha256:4885cb0e817aef5d00a2e8451d4665c1808378dc27c2705f1bf4ef8505c0d2e5", size = 42471, upload-time = "2026-01-26T02:45:38.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6d/f9293baa6146ba9507e360ea0292b6422b016907c393e2f63fc40ab7b7b5/multidict-6.7.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0458c978acd8e6ea53c81eefaddbbee9c6c5e591f41b3f5e8e194780fe026581", size = 82401, upload-time = "2026-01-26T02:45:40.254Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/53b5494738d83558d87c3c71a486504d8373421c3e0dbb6d0db48ad42ee0/multidict-6.7.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c0abd12629b0af3cf590982c0b413b1e7395cd4ec026f30986818ab95bfaa94a", size = 48143, upload-time = "2026-01-26T02:45:41.635Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e8/5284c53310dcdc99ce5d66563f6e5773531a9b9fe9ec7a615e9bc306b05f/multidict-6.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:14525a5f61d7d0c94b368a42cff4c9a4e7ba2d52e2672a7b23d84dc86fb02b0c", size = 46507, upload-time = "2026-01-26T02:45:42.99Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/fc/6800d0e5b3875568b4083ecf5f310dcf91d86d52573160834fb4bfcf5e4f/multidict-6.7.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17307b22c217b4cf05033dabefe68255a534d637c6c9b0cc8382718f87be4262", size = 239358, upload-time = "2026-01-26T02:45:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/41/75/4ad0973179361cdf3a113905e6e088173198349131be2b390f9fa4da5fc6/multidict-6.7.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a7e590ff876a3eaf1c02a4dfe0724b6e69a9e9de6d8f556816f29c496046e59", size = 246884, upload-time = "2026-01-26T02:45:47.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/095bb28b5da139bd41fb9a5d5caff412584f377914bd8787c2aa98717130/multidict-6.7.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5fa6a95dfee63893d80a34758cd0e0c118a30b8dcb46372bf75106c591b77889", size = 225878, upload-time = "2026-01-26T02:45:48.698Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d0/c0a72000243756e8f5a277b6b514fa005f2c73d481b7d9e47cd4568aa2e4/multidict-6.7.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a0543217a6a017692aa6ae5cc39adb75e587af0f3a82288b1492eb73dd6cc2a4", size = 253542, upload-time = "2026-01-26T02:45:50.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/6b/f69da15289e384ecf2a68837ec8b5ad8c33e973aa18b266f50fe55f24b8c/multidict-6.7.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f99fe611c312b3c1c0ace793f92464d8cd263cc3b26b5721950d977b006b6c4d", size = 252403, upload-time = "2026-01-26T02:45:51.779Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/76/b9669547afa5a1a25cd93eaca91c0da1c095b06b6d2d8ec25b713588d3a1/multidict-6.7.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9004d8386d133b7e6135679424c91b0b854d2d164af6ea3f289f8f2761064609", size = 244889, upload-time = "2026-01-26T02:45:53.27Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a9/a50d2669e506dad33cfc45b5d574a205587b7b8a5f426f2fbb2e90882588/multidict-6.7.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e628ef0e6859ffd8273c69412a2465c4be4a9517d07261b33334b5ec6f3c7489", size = 241982, upload-time = "2026-01-26T02:45:54.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/bb/1609558ad8b456b4827d3c5a5b775c93b87878fd3117ed3db3423dfbce1b/multidict-6.7.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:841189848ba629c3552035a6a7f5bf3b02eb304e9fea7492ca220a8eda6b0e5c", size = 232415, upload-time = "2026-01-26T02:45:56.981Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/59/6f61039d2aa9261871e03ab9dc058a550d240f25859b05b67fd70f80d4b3/multidict-6.7.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ce1bbd7d780bb5a0da032e095c951f7014d6b0a205f8318308140f1a6aba159e", size = 240337, upload-time = "2026-01-26T02:45:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/29/fdc6a43c203890dc2ae9249971ecd0c41deaedfe00d25cb6564b2edd99eb/multidict-6.7.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b26684587228afed0d50cf804cc71062cc9c1cdf55051c4c6345d372947b268c", size = 248788, upload-time = "2026-01-26T02:46:00.862Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/14/a153a06101323e4cf086ecee3faadba52ff71633d471f9685c42e3736163/multidict-6.7.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9f9af11306994335398293f9958071019e3ab95e9a707dc1383a35613f6abcb9", size = 242842, upload-time = "2026-01-26T02:46:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/604ae839e64a4a6efc80db94465348d3b328ee955e37acb24badbcd24d83/multidict-6.7.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b4938326284c4f1224178a560987b6cf8b4d38458b113d9b8c1db1a836e640a2", size = 240237, upload-time = "2026-01-26T02:46:05.898Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/c3a5187bf66f6fb546ff4ab8fb5a077cbdd832d7b1908d4365c7f74a1917/multidict-6.7.1-cp314-cp314t-win32.whl", hash = "sha256:98655c737850c064a65e006a3df7c997cd3b220be4ec8fe26215760b9697d4d7", size = 48008, upload-time = "2026-01-26T02:46:07.468Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "multipart"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/d6/9c4f366d6f9bb8f8fb5eae3acac471335c39510c42b537fd515213d7d8c3/multipart-1.3.1.tar.gz", hash = "sha256:211d7cfc1a7a43e75c4d24ee0e8e0f4f61d522f1a21575303ae85333dea687bf", size = 38929, upload-time = "2026-02-27T10:17:13.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/ed/e1f03200ee1f0bf4a2b9b72709afefbf5319b68df654e0b84b35c65613ee/multipart-1.3.1-py3-none-any.whl", hash = "sha256:a82b59e1befe74d3d30b3d3f70efd5a2eba4d938f845dcff9faace968888ff29", size = 15061, upload-time = "2026-02-27T10:17:11.943Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -776,6 +1048,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polyfactory"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "faker" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/68/7717bd9e63ed254617a7d3dc9260904fb736d6ea203e58ffddcb186c64e4/polyfactory-3.3.0.tar.gz", hash = "sha256:237258b6ff43edf362ffd1f68086bb796466f786adfa002b0ac256dbf2246e9a", size = 348668, upload-time = "2026-02-22T09:46:28.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/34/b6f19941adcdaf415b5e8a8d577499f5b6a76b59cbae37f9b125a9ffe9f2/polyfactory-3.3.0-py3-none-any.whl", hash = "sha256:686abcaa761930d3df87b91e95b26b8d8cb9fdbbbe0b03d5f918acff5c72606e", size = 62707, upload-time = "2026-02-22T09:46:25.985Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
 ]
 
 [[package]]
@@ -1011,6 +1309,98 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "rich-click"
+version = "1.9.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/27/091e140ea834272188e63f8dd6faac1f5c687582b687197b3e0ec3c78ebf/rich_click-1.9.7.tar.gz", hash = "sha256:022997c1e30731995bdbc8ec2f82819340d42543237f033a003c7b1f843fc5dc", size = 74838, upload-time = "2026-01-31T04:29:27.707Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/e5/d708d262b600a352abe01c2ae360d8ff75b0af819b78e9af293191d928e6/rich_click-1.9.7-py3-none-any.whl", hash = "sha256:2f99120fca78f536e07b114d3b60333bc4bb2a0969053b1250869bcdc1b5351b", size = 71491, upload-time = "2026-01-31T04:29:26.777Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1043,6 +1433,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -45,14 +45,14 @@ flowchart TB
 ### Core Concepts
 
 | Document | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | [**Overview**](overview.md) | Auth flow, JWT validation, user mapping |
 | [**Web Component**](web-component.md) | `<hotosm-auth>` Lit element |
 
 ### Project Implementations
 
 | Project | Stack | Documentation |
-|---------|-------|---------------|
+| --------- | ------- | --------------- |
 | Portal | FastAPI + React | [Implementation](projects/portal.md) |
 | Drone-TM | FastAPI + React | [Implementation](projects/drone-tm.md) |
 | fAIr | Django + React | [Implementation](projects/fair.md) |
@@ -71,6 +71,9 @@ pip install "hotosm-auth @ git+https://github.com/hotosm/login.git@auth-libs-v0.
 # With FastAPI
 pip install "hotosm-auth[fastapi] @ git+https://github.com/hotosm/login.git@auth-libs-v0.2.2#subdirectory=auth-libs/python"
 
+# With Litestar
+pip install "hotosm-auth[litestar] @ git+https://github.com/hotosm/login.git@auth-libs-v0.2.2#subdirectory=auth-libs/python"
+
 # With Django
 pip install "hotosm-auth[django] @ git+https://github.com/hotosm/login.git@auth-libs-v0.2.2#subdirectory=auth-libs/python"
 ```
@@ -79,7 +82,7 @@ pip install "hotosm-auth[django] @ git+https://github.com/hotosm/login.git@auth-
 
 Distributed as pre-built JS bundles. Copy from `auth-libs/web-component/dist/`:
 
-```
+```text
 hanko-auth.esm.js    # ES Module
 hanko-auth.iife.js   # Browser global
 hanko-auth.umd.js    # Universal
@@ -135,6 +138,20 @@ def my_view(request):
     return JsonResponse({"email": user.email})
 ```
 
+### Litestar (5 min)
+
+```python
+from litestar import Litestar, get
+from hotosm_auth_litestar import setup_auth, Auth
+
+@get("/me")
+async def me(auth: Auth):
+    return {"id": auth.user.id, "email": auth.user.email}
+
+deps, route_handlers = setup_auth()
+app = Litestar(route_handlers=[me, *route_handlers], dependencies=deps)
+```
+
 ### Frontend
 
 ```html
@@ -169,7 +186,7 @@ COOKIE_SECURE=true
 
 ## Source Repository
 
-```
+```text
 github.com/hotosm/login
 ├── backend/
 ├── frontend/
@@ -178,6 +195,7 @@ github.com/hotosm/login
 │   │   ├── src/
 │   │   │   ├── hotosm_auth/           # Core (JWT, config, crypto)
 │   │   │   ├── hotosm_auth_fastapi/   # FastAPI integration
+│   │   │   ├── hotosm_auth_litestar/  # Litestar integration
 │   │   │   └── hotosm_auth_django/    # Django integration
 │   │   └── pyproject.toml
 │   ├── web-component/

--- a/docs/src/integration-guide.md
+++ b/docs/src/integration-guide.md
@@ -5,8 +5,9 @@ Step by step guide to integrate `hotosm-auth` in your project.
 ## Quick Links
 
 | Framework | Without Legacy Auth | With Legacy Auth |
-|-----------|---------------------|------------------|
+| ----------- | --------------------- | ------------------ |
 | **FastAPI** | [Simple](#fastapi-simple-integration) | [With Mapping](#fastapi-integration-with-mapping) |
+| **Litestar** | [Simple](python-libs.md#litestar-hotosm_auth_litestar) | [With Mapping](python-libs.md#litestar-hotosm_auth_litestar) |
 | **Django** | [Simple](#django-simple-integration) | [With Mapping](#django-integration-with-mapping) |
 | **Frontend** | [All](#frontend-all) | [All](#frontend-all) |
 
@@ -14,7 +15,7 @@ Step by step guide to integrate `hotosm-auth` in your project.
 
 ## Step 0: Determine your case
 
-```
+```text
 Does your app have an existing auth system (legacy)?
 │
 ├─ NO → Simple Integration (Portal, OAM)
@@ -168,7 +169,7 @@ app.include_router(admin_router, prefix="/api/admin")
 
 ## Django: Simple Integration
 
-### Step 1: Dependency
+### Step 1: Dependency (Alternative)
 
 ```toml
 dependencies = [
@@ -255,11 +256,11 @@ VITE_HANKO_URL=https://login.hotosm.org
 
 ## Checklist
 
-| Step | FastAPI Simple | FastAPI+Mapping | Django Simple | Django+Mapping |
-|------|----------------|-----------------|---------------|----------------|
+| Step | FastAPI Std | FastAPI Map | Django Std | Django Map |
+| ------ | ----------- | ----------- | ---------- | ---------- |
 | Dependency | ✓ | ✓ | ✓ | ✓ |
 | init_auth / middleware | ✓ | ✓ | ✓ | ✓ |
-| Protect routes | CurrentUser | Override login_required | request.hotosm | request.hotosm |
+| Protect routes | CurrentUser | Override auth | req.hotosm | req.hotosm |
 | Helper functions | - | ✓ | - | ✓ |
 | Admin routes | - | Optional | - | Optional |
 | AUTH_PROVIDER env | - | ✓ | - | ✓ |

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -9,17 +9,18 @@
 - **User Mapping**: Maps Hanko users to app-specific user IDs
 
 | Component | Purpose |
-|-----------|---------|
+| ----------- | --------- |
 | `hotosm_auth` | Core Python package (JWT, config, crypto) |
 | `hotosm_auth_fastapi` | FastAPI integration (dependencies, routes) |
 | `hotosm_auth_django` | Django integration (middleware, decorators) |
+| `hotosm_auth_litestar` | Litestar integration (dependencies, routes) |
 | `<hotosm-auth>` | Web component (Lit-based auth UI) |
 
 ---
 
 ## Package Structure
 
-```
+```text
 auth-libs/
 │
 ├── python/src/                       # Python packages
@@ -35,6 +36,11 @@ auth-libs/
 │   │   ├── dependencies.py           # CurrentUser, OSMConnectionRequired
 │   │   ├── osm_routes.py             # /auth/osm/* endpoints
 │   │   └── admin_routes.py           # User mapping admin API
+│   │
+│   ├── hotosm_auth_litestar/         # Litestar integration
+│   │   ├── dependencies.py           # current_user, auth context providers
+│   │   ├── setup.py                  # setup_auth helper
+│   │   └── osm_routes.py             # /auth/osm/* endpoints
 │   │
 │   └── hotosm_auth_django/           # Django integration
 │       ├── middleware.py             # HankoAuthMiddleware
@@ -75,7 +81,7 @@ Apps with existing users need to map Hanko UUIDs to app user IDs.
 
 ### Problem
 
-```
+```text
 Hanko: id="550e8400-..."    ←→    App: id=42
        email=user@x.com            email=user@x.com
 ```
@@ -146,7 +152,9 @@ flowchart TD
     Q --> I
 ```
 
-> **Key Difference**: FastAPI supports auto-creation with `email_lookup_fn` and `user_creator_fn`. Django defaults to `auto_create=False`, expecting the app to handle onboarding (e.g., after OSM connect).
+> **Key Difference**: FastAPI supports auto-creation with `email_lookup_fn` and
+> `user_creator_fn`. Django defaults to `auto_create=False`, so the app handles
+> onboarding (for example, after OSM connect).
 
 ---
 
@@ -186,15 +194,15 @@ VITE_HANKO_URL=https://login.hotosm.org
 ### Variables by Project
 
 | Variable | Portal | Drone-TM | fAIr | OAM | Login |
-|----------|--------|----------|------|-----|-------|
-| **Backend** |
+| ---------- | -------- | ---------- | ------ | ----- | ------- |
+| **Backend** | | | | | |
 | `HANKO_API_URL` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `COOKIE_SECRET` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `OSM_CLIENT_ID` | ✅ | - | ✅ | - | ✅ |
 | `OSM_CLIENT_SECRET` | ✅ | - | ✅ | - | ✅ |
 | `ADMIN_EMAILS` | ✅ | ✅ | ✅ | - | - |
 | `AUTH_PROVIDER` | - | ✅ | ✅ | - | - |
-| **Frontend** |
+| **Frontend** | | | | | |
 | `VITE_HANKO_URL` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `VITE_AUTH_PROVIDER` | - | ✅ | ✅ | - | - |
 

--- a/docs/src/python-libs.md
+++ b/docs/src/python-libs.md
@@ -44,7 +44,7 @@ class AuthConfig(BaseModel):
         """Load from environment variables."""
 ```
 
-**Smart Defaults:**
+### Smart Defaults
 
 - `cookie_domain`: `login.hotosm.org` → `.hotosm.org`
 - `cookie_secure`: `https://` → `True`
@@ -153,7 +153,7 @@ class CookieCrypto:
 
 ## FastAPI: `hotosm_auth_fastapi`
 
-### Simple Setup
+### FastAPI Simple Setup
 
 ```python
 from fastapi import FastAPI
@@ -175,7 +175,7 @@ async def upload(auth: Auth):
     return {"token": osm.access_token}
 ```
 
-### Manual Setup
+### FastAPI Manual Setup
 
 ```python
 from hotosm_auth import AuthConfig
@@ -215,7 +215,7 @@ async def edit(osm: OSMConnectionRequired):
 ### Dependencies
 
 | Dependency | Type | Raises |
-|------------|------|--------|
+| ------------ | ------ | -------- |
 | `CurrentUser` | `HankoUser` | 401 |
 | `CurrentUserOptional` | `Optional[HankoUser]` | - |
 | `OSMConnectionDep` | `Optional[OSMConnection]` | - |
@@ -223,7 +223,7 @@ async def edit(osm: OSMConnectionRequired):
 
 ### OSM Routes
 
-```
+```text
 GET  /auth/osm/login      → Redirect to OSM authorization
 GET  /auth/osm/callback   → Handle OAuth callback, set cookie
 GET  /auth/osm/status     → {"connected": true, "osm_username": "..."}
@@ -249,12 +249,95 @@ app.include_router(admin_router, prefix="/api/admin")
 
 Endpoints:
 
-```
+```text
 GET    /mappings              → List all mappings (paginated)
 POST   /mappings              → Create mapping
 GET    /mappings/{hanko_id}   → Get single mapping
 PUT    /mappings/{hanko_id}   → Update mapping
 DELETE /mappings/{hanko_id}   → Delete mapping
+```
+
+---
+
+## Litestar: `hotosm_auth_litestar`
+
+### Litestar Simple Setup
+
+```python
+from litestar import Litestar, get
+from hotosm_auth_litestar import setup_auth, AuthContext
+
+
+@get("/me")
+async def me(auth: AuthContext) -> dict[str, str]:
+    return {"email": auth.user.email}
+
+
+deps, route_handlers = setup_auth()  # Loads from .env
+app = Litestar(
+    route_handlers=[me, *route_handlers],
+    dependencies=deps,
+)
+```
+
+### Litestar Manual Setup
+
+```python
+from litestar import Litestar, get
+from hotosm_auth import AuthConfig
+from hotosm_auth_litestar import (
+    create_dependencies,
+    init_auth,
+    osm_router,
+    AuthContext,
+)
+
+
+@get("/protected")
+async def protected(auth: AuthContext):
+    return {"id": auth.user.id}
+
+
+config = AuthConfig.from_env()
+init_auth(config)
+
+app = Litestar(
+    route_handlers=[protected, osm_router],
+    dependencies=create_dependencies(),
+)
+```
+
+Default dependency keys:
+
+| Key | Type | Raises |
+| --- | --- | --- |
+| `current_user` | `HankoUser` | 401 |
+| `current_user_optional` | `Optional[HankoUser]` | - |
+| `osm_connection` | `Optional[OSMConnection]` | - |
+| `osm_connection_required` | `OSMConnection` | 403 |
+| `auth` | `AuthContext` | 401 |
+| `optional_auth` | `OptionalAuthContext` | - |
+
+### Admin Routes (psycopg)
+
+```python
+from hotosm_auth_litestar import create_admin_mappings_router
+
+# get_db should provide a psycopg AsyncConnection
+admin_router = create_admin_mappings_router(
+    get_db,
+    app_name="drone-tm",
+    user_table="users",
+    user_id_column="id",
+    user_name_column="name",
+    user_email_column="email",
+)
+
+deps, route_handlers = setup_auth()
+app = Litestar(
+    route_handlers=[*route_handlers, admin_router],
+    dependencies=deps,
+)
 ```
 
 ---
@@ -320,7 +403,7 @@ class HankoAuthMiddleware:
     """
 ```
 
-### Admin Routes
+### Admin Routes (Alternative)
 
 ```python
 # urls.py


### PR DESCRIPTION
- Add LiteStar as an auth lib option, in a similar way to FastAPI and Django.
- I used Opus 4.6 LLM to generate the code, based on the other integrations (seems most of the other code is too, so it made sense to me - fast too).
- I'll give this a test in FieldTM to see if it works well, before we publish the package.