### PR TITLE
Add teams and organizations

### DIFF
--- a/auth-libs/python/src/hotosm_auth_fastapi/__init__.py
+++ b/auth-libs/python/src/hotosm_auth_fastapi/__init__.py
@@ -2,6 +2,8 @@
 
 # Core dependencies
 # Admin functionality
+# PAT resolver (re-exported from core)
+from hotosm_auth.remote_resolver import remote_pat_resolver
 from hotosm_auth_fastapi.admin import (
     AdminUser,
     require_admin,
@@ -35,9 +37,6 @@ from hotosm_auth_fastapi.dependencies import (
 
 # OSM routes
 from hotosm_auth_fastapi.osm_routes import router as osm_router
-
-# PAT resolver (re-exported from core)
-from hotosm_auth.remote_resolver import remote_pat_resolver
 
 # Simple setup API
 from hotosm_auth_fastapi.setup import (

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -8,7 +8,13 @@ from alembic import context
 
 # Import our models and Base
 from app.db.database import Base
-from app.db.models import UserProfile  # noqa: F401 - needed for autogenerate
+from app.db.models import (  # noqa: F401 - needed for autogenerate
+    AccountManager,
+    Group,
+    GroupInvitation,
+    GroupMembership,
+    UserProfile,
+)
 from app.core.config import settings
 
 # this is the Alembic Config object

--- a/backend/alembic/versions/003_create_groups.py
+++ b/backend/alembic/versions/003_create_groups.py
@@ -1,0 +1,69 @@
+"""Create groups table.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-07-20
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "003"
+down_revision: str | None = "002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create groups table (teams and organizations)."""
+    op.create_table(
+        "groups",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("type", sa.String(20), nullable=False),
+        sa.Column("name", sa.String(200), nullable=False),
+        sa.Column("slug", sa.String(80), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("contact_email", sa.String(320), nullable=True),
+        sa.Column("website", sa.String(500), nullable=True),
+        sa.Column("avatar_key", sa.String(500), nullable=True),
+        sa.Column("banner_key", sa.String(500), nullable=True),
+        sa.Column(
+            "status", sa.String(20), nullable=False, server_default="approved"
+        ),
+        sa.Column("pending_name", sa.String(200), nullable=True),
+        sa.Column(
+            "is_public",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("created_by", sa.String(36), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "type IN ('team', 'organization')", name="ck_groups_type"
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending', 'approved', 'rejected')",
+            name="ck_groups_status",
+        ),
+        sa.UniqueConstraint("type", "slug", name="ux_groups_type_slug"),
+    )
+    op.create_index("ix_groups_type_status", "groups", ["type", "status"])
+    op.create_index("ix_groups_created_by", "groups", ["created_by"])
+
+
+def downgrade() -> None:
+    """Drop groups table."""
+    op.drop_index("ix_groups_created_by", table_name="groups")
+    op.drop_index("ix_groups_type_status", table_name="groups")
+    op.drop_table("groups")

--- a/backend/alembic/versions/004_create_group_memberships.py
+++ b/backend/alembic/versions/004_create_group_memberships.py
@@ -1,0 +1,60 @@
+"""Create group_memberships table.
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-07-20
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "004"
+down_revision: str | None = "003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create group_memberships table."""
+    op.create_table(
+        "group_memberships",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column(
+            "group_id",
+            sa.String(36),
+            sa.ForeignKey("groups.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("hanko_user_id", sa.String(36), nullable=False),
+        sa.Column("role", sa.String(20), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "role IN ('owner', 'manager', 'member')",
+            name="ck_group_memberships_role",
+        ),
+        sa.UniqueConstraint(
+            "group_id", "hanko_user_id", name="ux_group_memberships_group_user"
+        ),
+    )
+    op.create_index(
+        "ix_group_memberships_user", "group_memberships", ["hanko_user_id"]
+    )
+    op.create_index(
+        "ix_group_memberships_group", "group_memberships", ["group_id"]
+    )
+
+
+def downgrade() -> None:
+    """Drop group_memberships table."""
+    op.drop_index("ix_group_memberships_group", table_name="group_memberships")
+    op.drop_index("ix_group_memberships_user", table_name="group_memberships")
+    op.drop_table("group_memberships")

--- a/backend/alembic/versions/005_create_group_invitations.py
+++ b/backend/alembic/versions/005_create_group_invitations.py
@@ -1,0 +1,82 @@
+"""Create group_invitations table.
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-07-20
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "005"
+down_revision: str | None = "004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create group_invitations table (organizations only)."""
+    op.create_table(
+        "group_invitations",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column(
+            "group_id",
+            sa.String(36),
+            sa.ForeignKey("groups.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("email", sa.String(320), nullable=False),
+        sa.Column(
+            "role", sa.String(20), nullable=False, server_default="member"
+        ),
+        sa.Column(
+            "status", sa.String(20), nullable=False, server_default="pending"
+        ),
+        sa.Column("token", sa.String(64), nullable=False, unique=True),
+        sa.Column("invited_by", sa.String(36), nullable=False),
+        sa.Column("invited_hanko_user_id", sa.String(36), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("responded_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "status IN ('pending', 'accepted', 'declined', 'expired', 'revoked')",
+            name="ck_group_invitations_status",
+        ),
+        sa.CheckConstraint(
+            "role IN ('owner', 'manager', 'member')",
+            name="ck_group_invitations_role",
+        ),
+    )
+    # At most one live (pending) invitation per (group, email).
+    op.create_index(
+        "ux_group_invitations_pending",
+        "group_invitations",
+        ["group_id", "email"],
+        unique=True,
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+    op.create_index(
+        "ix_group_invitations_email", "group_invitations", ["email"]
+    )
+    op.create_index(
+        "ix_group_invitations_group", "group_invitations", ["group_id"]
+    )
+
+
+def downgrade() -> None:
+    """Drop group_invitations table."""
+    op.drop_index("ix_group_invitations_group", table_name="group_invitations")
+    op.drop_index("ix_group_invitations_email", table_name="group_invitations")
+    op.drop_index(
+        "ux_group_invitations_pending", table_name="group_invitations"
+    )
+    op.drop_table("group_invitations")

--- a/backend/alembic/versions/006_create_account_managers.py
+++ b/backend/alembic/versions/006_create_account_managers.py
@@ -1,0 +1,38 @@
+"""Create account_managers table.
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-07-20
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "006"
+down_revision: str | None = "005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create account_managers table."""
+    op.create_table(
+        "account_managers",
+        sa.Column("hanko_user_id", sa.String(36), primary_key=True),
+        sa.Column("granted_by", sa.String(36), nullable=False),
+        sa.Column(
+            "granted_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop account_managers table."""
+    op.drop_table("account_managers")

--- a/backend/alembic/versions/007_add_user_profiles_slug.py
+++ b/backend/alembic/versions/007_add_user_profiles_slug.py
@@ -1,0 +1,35 @@
+"""Add slug column to user_profiles.
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-07-20
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "007"
+down_revision: str | None = "006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add nullable unique slug for public user profiles (/user/{slug})."""
+    op.add_column(
+        "user_profiles",
+        sa.Column("slug", sa.String(80), nullable=True),
+    )
+    op.create_index(
+        "ux_user_profiles_slug", "user_profiles", ["slug"], unique=True
+    )
+
+
+def downgrade() -> None:
+    """Drop slug column from user_profiles."""
+    op.drop_index("ux_user_profiles_slug", table_name="user_profiles")
+    op.drop_column("user_profiles", "slug")

--- a/backend/app/api/routes/admin.py
+++ b/backend/app/api/routes/admin.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from hotosm_auth.models import HankoUser
 from hotosm_auth_fastapi import get_current_user
 
+from app.core.authz import AccountManagerUser
 from app.core.config import settings
 
 router = APIRouter(prefix="/api/admin", tags=["Admin"])
@@ -992,7 +993,7 @@ async def get_recent_users(
 
 @router.get("/stats/users/search")
 async def search_users(  # noqa: PLR0913
-    admin: AdminUser,
+    admin: AccountManagerUser,
     request: Request,
     email: str | None = Query(None, description="Search by email (partial match)"),
     date_from: str | None = Query(None, description="Filter from date (YYYY-MM-DD)"),

--- a/backend/app/api/routes/api_token.py
+++ b/backend/app/api/routes/api_token.py
@@ -162,9 +162,7 @@ async def resolve_token(
 
     # Load user profile
     profile_result = await db.execute(
-        select(UserProfile).where(
-            UserProfile.hanko_user_id == token_row.hanko_user_id
-        )
+        select(UserProfile).where(UserProfile.hanko_user_id == token_row.hanko_user_id)
     )
     profile = profile_result.scalar_one_or_none()
     if not profile:

--- a/backend/app/api/routes/data_deletion.py
+++ b/backend/app/api/routes/data_deletion.py
@@ -33,9 +33,7 @@ async def _send_deletion_email_safe(
     """Wrapper used as a BackgroundTask: log success/failure, never raise."""
     try:
         await send_email(to=to, subject=subject, text_body=text_body)
-        logger.info(
-            "Data deletion email sent for hanko_user_id=%s", hanko_user_id
-        )
+        logger.info("Data deletion email sent for hanko_user_id=%s", hanko_user_id)
     except Exception:
         logger.exception(
             "Failed to send data deletion email for hanko_user_id=%s",

--- a/backend/app/api/routes/groups.py
+++ b/backend/app/api/routes/groups.py
@@ -1,0 +1,425 @@
+"""Teams and organizations: CRUD, members and images.
+
+Invitations live in ``routes/invitations.py``; account-manager and public
+endpoints live in ``routes/organizations_admin.py`` and ``routes/public.py``.
+"""
+
+import io
+from typing import Annotated
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    HTTPException,
+    Query,
+    Response,
+    UploadFile,
+    status,
+)
+from hotosm_auth.models import HankoUser
+from hotosm_auth_fastapi import get_current_user
+from PIL import Image, ImageOps
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_db
+from app.db.models import Group, GroupMembership
+from app.schemas.groups import (
+    GroupCreate,
+    GroupResponse,
+    GroupUpdate,
+    MemberAdd,
+    MemberListResponse,
+    MemberRoleUpdate,
+    MembershipCheckResponse,
+    MyGroupsResponse,
+    NameChangeRequest,
+)
+from app.services import groups_service, hanko_lookup, s3_service
+
+router = APIRouter(prefix="/api/groups", tags=["Groups"])
+
+CurrentUser = Annotated[HankoUser, Depends(get_current_user)]
+DB = Annotated[AsyncSession, Depends(get_db)]
+
+_ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/jpg", "image/png", "image/webp"}
+_MAX_IMAGE_SIZE = 5 * 1024 * 1024  # 5 MB
+_AVATAR_SIZE = 512  # square side, px
+_BANNER_MAX_WIDTH = 1600  # px
+
+
+_load_group_or_404 = groups_service.load_group_or_404
+_require_access = groups_service.require_access
+_require_role = groups_service.require_role
+
+
+async def _add_team_members_by_email(
+    db: AsyncSession, group_id: str, emails: list[str], owner_id: str
+) -> None:
+    """Resolve emails to accounts and add them as members (skip unknown/dupes)."""
+    seen = {owner_id}
+    for raw in emails:
+        member_id = await hanko_lookup.email_to_user_id(raw.strip().lower())
+        if member_id is None or member_id in seen:
+            continue
+        seen.add(member_id)
+        db.add(
+            GroupMembership(
+                group_id=group_id, hanko_user_id=member_id, role="member"
+            )
+        )
+
+
+# --- Group CRUD ------------------------------------------------------------
+
+
+@router.post("", response_model=GroupResponse, status_code=status.HTTP_201_CREATED)
+async def create_group(payload: GroupCreate, user: CurrentUser, db: DB) -> GroupResponse:
+    """Create a team (approved) or organization (pending approval)."""
+    slug = await groups_service.generate_unique_slug(
+        db, payload.type, payload.name
+    )
+    group = Group(
+        type=payload.type,
+        name=payload.name,
+        slug=slug,
+        description=payload.description,
+        contact_email=payload.contact_email,
+        website=payload.website,
+        status="pending" if payload.type == "organization" else "approved",
+        created_by=user.id,
+    )
+    db.add(group)
+    await db.flush()
+
+    db.add(
+        GroupMembership(group_id=group.id, hanko_user_id=user.id, role="owner")
+    )
+    # Teams may seed members directly by email; orgs use invitations.
+    if payload.type == "team" and payload.member_emails:
+        await _add_team_members_by_email(
+            db, group.id, payload.member_emails, user.id
+        )
+    await db.commit()
+    await db.refresh(group)
+    members_count = await groups_service.count_members(db, group.id)
+    return groups_service.serialize_group(
+        group, role="owner", members_count=members_count
+    )
+
+
+@router.get("", response_model=MyGroupsResponse)
+async def list_my_groups(
+    user: CurrentUser,
+    db: DB,
+    type: Annotated[str | None, Query()] = None,
+) -> MyGroupsResponse:
+    """List the groups the current user belongs to (consumer contract).
+
+    This is the canonical endpoint portal consumes (forwarding the hanko
+    cookie) to resolve membership, and that the login frontend uses to render
+    the Organizations/Teams lists. Optional ``type`` filters team|organization.
+    """
+    pairs = await groups_service.list_user_groups(db, user.id, type)
+    return MyGroupsResponse(
+        groups=[groups_service.to_my_group_item(g, role) for g, role in pairs]
+    )
+
+
+@router.get("/{group_id}", response_model=GroupResponse)
+async def get_group(group_id: str, user: CurrentUser, db: DB) -> GroupResponse:
+    """Get a group's details (members and account managers only)."""
+    group = await _load_group_or_404(db, group_id)
+    role = await _require_access(db, group, user)
+    members_count = await groups_service.count_members(db, group.id)
+    return groups_service.serialize_group(
+        group, role=role, members_count=members_count
+    )
+
+
+@router.patch("/{group_id}", response_model=GroupResponse)
+async def update_group(
+    group_id: str, payload: GroupUpdate, user: CurrentUser, db: DB
+) -> GroupResponse:
+    """Update group details (owner/manager). The name is not editable here."""
+    group = await _load_group_or_404(db, group_id)
+    role = await _require_role(db, group, user, "manager")
+
+    data = payload.model_dump(exclude_unset=True)
+    for field in ("description", "contact_email", "website", "is_public"):
+        if field in data:
+            setattr(group, field, data[field])
+    await db.commit()
+    await db.refresh(group)
+    members_count = await groups_service.count_members(db, group.id)
+    return groups_service.serialize_group(
+        group, role=role, members_count=members_count
+    )
+
+
+@router.post("/{group_id}/name-change", response_model=GroupResponse)
+async def change_group_name(
+    group_id: str, payload: NameChangeRequest, user: CurrentUser, db: DB
+) -> GroupResponse:
+    """Change a group's name (owner only).
+
+    Teams apply the change directly. Approved organizations stage it in
+    ``pending_name`` for account-manager approval; pending orgs apply directly.
+    """
+    group = await _load_group_or_404(db, group_id)
+    role = await _require_role(db, group, user, "owner")
+
+    if group.type == "organization" and group.status == "approved":
+        group.pending_name = payload.name
+    else:
+        group.name = payload.name
+        group.slug = await groups_service.generate_unique_slug(
+            db, group.type, payload.name
+        )
+    await db.commit()
+    await db.refresh(group)
+    members_count = await groups_service.count_members(db, group.id)
+    return groups_service.serialize_group(
+        group, role=role, members_count=members_count
+    )
+
+
+@router.delete("/{group_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_group(group_id: str, user: CurrentUser, db: DB) -> Response:
+    """Delete a group (owner only). Memberships cascade."""
+    group = await _load_group_or_404(db, group_id)
+    await _require_role(db, group, user, "owner")
+    await db.delete(group)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# --- Members ---------------------------------------------------------------
+
+
+@router.get(
+    "/{group_id}/membership/{member_user_id}",
+    response_model=MembershipCheckResponse,
+)
+async def check_membership(
+    group_id: str,
+    member_user_id: str,
+    user: CurrentUser,
+    db: DB,
+    min_role: Annotated[str, Query()] = "member",
+) -> MembershipCheckResponse:
+    """Check whether a user is a member of a group (with >= min_role).
+
+    Consumer contract for other apps. The requester must be a member of the
+    group (or an account manager) to query it.
+    """
+    group = await _load_group_or_404(db, group_id)
+    await _require_access(db, group, user)
+    role = await groups_service.get_user_role(db, group_id, member_user_id)
+    satisfies = role is not None and groups_service.role_rank(
+        role
+    ) >= groups_service.role_rank(min_role)
+    return MembershipCheckResponse(
+        is_member=role is not None, role=role, satisfies_min_role=satisfies
+    )
+
+
+@router.get("/{group_id}/members", response_model=MemberListResponse)
+async def list_group_members(
+    group_id: str,
+    user: CurrentUser,
+    db: DB,
+    page: Annotated[int, Query(ge=1)] = 1,
+    page_size: Annotated[int, Query(ge=1, le=100)] = 50,
+) -> MemberListResponse:
+    """List a group's members (members and account managers only)."""
+    group = await _load_group_or_404(db, group_id)
+    await _require_access(db, group, user)
+    items, total = await groups_service.list_members(
+        db, group_id, page, page_size
+    )
+    return MemberListResponse(
+        items=items, total=total, page=page, page_size=page_size
+    )
+
+
+@router.post(
+    "/{group_id}/members",
+    response_model=MemberListResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_group_member(
+    group_id: str, payload: MemberAdd, user: CurrentUser, db: DB
+) -> MemberListResponse:
+    """Add a member directly by email (teams only).
+
+    Resolves the email to a HOT account; organizations must use invitations.
+    """
+    group = await _load_group_or_404(db, group_id)
+    await _require_role(db, group, user, "manager")
+    if group.type == "organization":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Organizations add members via invitations",
+        )
+    member_id = await hanko_lookup.email_to_user_id(payload.email.strip().lower())
+    if member_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No HOT account found with that email",
+        )
+    existing = await groups_service.get_membership(db, group_id, member_id)
+    if existing is None:
+        db.add(
+            GroupMembership(
+                group_id=group_id, hanko_user_id=member_id, role=payload.role
+            )
+        )
+        await db.commit()
+    items, total = await groups_service.list_members(db, group_id, 1, 50)
+    return MemberListResponse(items=items, total=total, page=1, page_size=50)
+
+
+@router.patch("/{group_id}/members/{member_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def update_member_role(
+    group_id: str,
+    member_id: str,
+    payload: MemberRoleUpdate,
+    user: CurrentUser,
+    db: DB,
+) -> Response:
+    """Change a member's role (owner only).
+
+    Setting ``owner`` transfers ownership: the current owner becomes a manager,
+    keeping exactly one owner per group.
+    """
+    group = await _load_group_or_404(db, group_id)
+    await _require_role(db, group, user, "owner")
+
+    target = await groups_service.get_membership(db, group_id, member_id)
+    if target is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Member not found"
+        )
+    if payload.role == "owner" and member_id != user.id:
+        current = await groups_service.get_membership(db, group_id, user.id)
+        if current is not None:
+            current.role = "manager"
+    target.role = payload.role
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.delete("/{group_id}/members/{member_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_group_member(
+    group_id: str, member_id: str, user: CurrentUser, db: DB
+) -> Response:
+    """Remove a member (owner/manager) or leave the group (self)."""
+    group = await _load_group_or_404(db, group_id)
+    target = await groups_service.get_membership(db, group_id, member_id)
+    if target is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Member not found"
+        )
+    if member_id == user.id:
+        # Self-removal (leave); the sole owner must transfer or delete instead.
+        if target.role == "owner":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Owner must transfer ownership or delete the group",
+            )
+    else:
+        actor_role = await _require_role(db, group, user, "manager")
+        if target.role == "owner" or (
+            target.role == "manager" and actor_role != "owner"
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Cannot remove this member",
+            )
+    await db.delete(target)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# --- Avatar / banner -------------------------------------------------------
+
+
+def _process_image(data: bytes, kind: str) -> bytes:
+    """Resize/normalize an image to WEBP (avatar square, banner wide)."""
+    img = Image.open(io.BytesIO(data)).convert("RGB")
+    if kind == "avatar":
+        img = ImageOps.fit(img, (_AVATAR_SIZE, _AVATAR_SIZE))
+    elif img.width > _BANNER_MAX_WIDTH:
+        ratio = _BANNER_MAX_WIDTH / img.width
+        img = img.resize((_BANNER_MAX_WIDTH, int(img.height * ratio)))
+    buf = io.BytesIO()
+    img.save(buf, format="WEBP", quality=85)
+    return buf.getvalue()
+
+
+async def _set_group_image(
+    group_id: str, kind: str, file: UploadFile, user: HankoUser, db: AsyncSession
+) -> dict[str, str]:
+    group = await _load_group_or_404(db, group_id)
+    await _require_role(db, group, user, "manager")
+
+    if file.content_type not in _ALLOWED_IMAGE_TYPES:
+        raise HTTPException(status_code=415, detail="Unsupported image type")
+    data = await file.read()
+    if len(data) > _MAX_IMAGE_SIZE:
+        raise HTTPException(status_code=413, detail="File too large (max 5 MB)")
+
+    processed = _process_image(data, kind)
+    key = s3_service.store_image(processed, group_id, kind, ".webp", "image/webp")
+
+    old_key = group.avatar_key if kind == "avatar" else group.banner_key
+    if kind == "avatar":
+        group.avatar_key = key
+    else:
+        group.banner_key = key
+    await db.commit()
+    if old_key:
+        s3_service.remove_image(old_key)
+    return {f"{kind}_url": groups_service.image_url(group_id, kind, key)}
+
+
+@router.put("/{group_id}/avatar")
+async def upload_avatar(
+    group_id: str, user: CurrentUser, db: DB, file: UploadFile = File(...)
+) -> dict[str, str]:
+    """Upload a group's avatar (owner/manager)."""
+    return await _set_group_image(group_id, "avatar", file, user, db)
+
+
+@router.put("/{group_id}/banner")
+async def upload_banner(
+    group_id: str, user: CurrentUser, db: DB, file: UploadFile = File(...)
+) -> dict[str, str]:
+    """Upload a group's banner (owner/manager)."""
+    return await _set_group_image(group_id, "banner", file, user, db)
+
+
+async def _serve_group_image(group_id: str, kind: str, db: AsyncSession) -> Response:
+    group = await _load_group_or_404(db, group_id)
+    key = group.avatar_key if kind == "avatar" else group.banner_key
+    if not key:
+        raise HTTPException(status_code=404, detail="Image not found")
+    data, content_type = s3_service.load_image(key)
+    return Response(
+        content=data,
+        media_type=content_type,
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+@router.get("/{group_id}/avatar", include_in_schema=False)
+async def get_avatar(group_id: str, db: DB) -> Response:
+    """Serve a group's avatar image."""
+    return await _serve_group_image(group_id, "avatar", db)
+
+
+@router.get("/{group_id}/banner", include_in_schema=False)
+async def get_banner(group_id: str, db: DB) -> Response:
+    """Serve a group's banner image."""
+    return await _serve_group_image(group_id, "banner", db)

--- a/backend/app/api/routes/groups.py
+++ b/backend/app/api/routes/groups.py
@@ -64,9 +64,7 @@ async def _add_team_members_by_email(
             continue
         seen.add(member_id)
         db.add(
-            GroupMembership(
-                group_id=group_id, hanko_user_id=member_id, role="member"
-            )
+            GroupMembership(group_id=group_id, hanko_user_id=member_id, role="member")
         )
 
 
@@ -74,11 +72,11 @@ async def _add_team_members_by_email(
 
 
 @router.post("", response_model=GroupResponse, status_code=status.HTTP_201_CREATED)
-async def create_group(payload: GroupCreate, user: CurrentUser, db: DB) -> GroupResponse:
+async def create_group(
+    payload: GroupCreate, user: CurrentUser, db: DB
+) -> GroupResponse:
     """Create a team (approved) or organization (pending approval)."""
-    slug = await groups_service.generate_unique_slug(
-        db, payload.type, payload.name
-    )
+    slug = await groups_service.generate_unique_slug(db, payload.type, payload.name)
     group = Group(
         type=payload.type,
         name=payload.name,
@@ -92,14 +90,10 @@ async def create_group(payload: GroupCreate, user: CurrentUser, db: DB) -> Group
     db.add(group)
     await db.flush()
 
-    db.add(
-        GroupMembership(group_id=group.id, hanko_user_id=user.id, role="owner")
-    )
+    db.add(GroupMembership(group_id=group.id, hanko_user_id=user.id, role="owner"))
     # Teams may seed members directly by email; orgs use invitations.
     if payload.type == "team" and payload.member_emails:
-        await _add_team_members_by_email(
-            db, group.id, payload.member_emails, user.id
-        )
+        await _add_team_members_by_email(db, group.id, payload.member_emails, user.id)
     await db.commit()
     await db.refresh(group)
     members_count = await groups_service.count_members(db, group.id)
@@ -132,9 +126,7 @@ async def get_group(group_id: str, user: CurrentUser, db: DB) -> GroupResponse:
     group = await _load_group_or_404(db, group_id)
     role = await _require_access(db, group, user)
     members_count = await groups_service.count_members(db, group.id)
-    return groups_service.serialize_group(
-        group, role=role, members_count=members_count
-    )
+    return groups_service.serialize_group(group, role=role, members_count=members_count)
 
 
 @router.patch("/{group_id}", response_model=GroupResponse)
@@ -152,9 +144,7 @@ async def update_group(
     await db.commit()
     await db.refresh(group)
     members_count = await groups_service.count_members(db, group.id)
-    return groups_service.serialize_group(
-        group, role=role, members_count=members_count
-    )
+    return groups_service.serialize_group(group, role=role, members_count=members_count)
 
 
 @router.post("/{group_id}/name-change", response_model=GroupResponse)
@@ -179,9 +169,7 @@ async def change_group_name(
     await db.commit()
     await db.refresh(group)
     members_count = await groups_service.count_members(db, group.id)
-    return groups_service.serialize_group(
-        group, role=role, members_count=members_count
-    )
+    return groups_service.serialize_group(group, role=role, members_count=members_count)
 
 
 @router.delete("/{group_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -235,12 +223,8 @@ async def list_group_members(
     """List a group's members (members and account managers only)."""
     group = await _load_group_or_404(db, group_id)
     await _require_access(db, group, user)
-    items, total = await groups_service.list_members(
-        db, group_id, page, page_size
-    )
-    return MemberListResponse(
-        items=items, total=total, page=page, page_size=page_size
-    )
+    items, total = await groups_service.list_members(db, group_id, page, page_size)
+    return MemberListResponse(items=items, total=total, page=page, page_size=page_size)
 
 
 @router.post(
@@ -310,7 +294,9 @@ async def update_member_role(
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@router.delete("/{group_id}/members/{member_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{group_id}/members/{member_id}", status_code=status.HTTP_204_NO_CONTENT
+)
 async def remove_group_member(
     group_id: str, member_id: str, user: CurrentUser, db: DB
 ) -> Response:

--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -68,9 +68,7 @@ def _invite_link(token: str) -> str:
     return f"{base}/app/invite?token={token}"
 
 
-async def _send_invite_email_safe(
-    *, to: str, group_name: str, token: str
-) -> None:
+async def _send_invite_email_safe(*, to: str, group_name: str, token: str) -> None:
     """BackgroundTask: send the invite email, never raise."""
     try:
         link = _invite_link(token)
@@ -212,9 +210,7 @@ async def revoke_invitation(
 # --- Recipient-side (the invited user) -------------------------------------
 
 
-async def _get_pending_invitation(
-    db: AsyncSession, token: str
-) -> GroupInvitation:
+async def _get_pending_invitation(db: AsyncSession, token: str) -> GroupInvitation:
     result = await db.execute(
         select(GroupInvitation).where(GroupInvitation.token == token)
     )
@@ -227,9 +223,7 @@ async def _get_pending_invitation(
 
 
 @me_router.get("", response_model=list[MyInvitationResponse])
-async def list_my_invitations(
-    user: CurrentUser, db: DB
-) -> list[MyInvitationResponse]:
+async def list_my_invitations(user: CurrentUser, db: DB) -> list[MyInvitationResponse]:
     """List the current user's pending, unexpired invitations."""
     if not user.email:
         return []
@@ -282,9 +276,7 @@ async def accept_invitation(token: str, user: CurrentUser, db: DB) -> Response:
             status_code=status.HTTP_410_GONE, detail="Invitation has expired"
         )
 
-    existing = await groups_service.get_membership(
-        db, invitation.group_id, user.id
-    )
+    existing = await groups_service.get_membership(db, invitation.group_id, user.id)
     if existing is None:
         db.add(
             GroupMembership(

--- a/backend/app/api/routes/invitations.py
+++ b/backend/app/api/routes/invitations.py
@@ -1,0 +1,315 @@
+"""Organization invitations.
+
+Invitations are email-anchored: the invitee may not have an account yet, so
+the ``hanko_user_id`` is resolved only on accept. Teams do not use invitations
+(members are added directly via ``routes/groups.py``).
+"""
+
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Annotated
+
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Response,
+    status,
+)
+from hotosm_auth.models import HankoUser
+from hotosm_auth_fastapi import get_current_user
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.db import get_db
+from app.db.models import Group, GroupInvitation, GroupMembership
+from app.schemas.groups import (
+    InvitationCreate,
+    InvitationResponse,
+    MyInvitationResponse,
+)
+from app.services import groups_service, hanko_lookup
+from app.services.email import send_email
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/groups", tags=["Invitations"])
+me_router = APIRouter(prefix="/api/me/invitations", tags=["Invitations"])
+
+CurrentUser = Annotated[HankoUser, Depends(get_current_user)]
+DB = Annotated[AsyncSession, Depends(get_db)]
+
+_INVITE_TTL_DAYS = 14
+_MAX_EMAIL_LEN = 320
+
+
+def _looks_like_email(value: str) -> bool:
+    """Cheap email sanity check (no external validator dependency)."""
+    if "@" not in value or len(value) > _MAX_EMAIL_LEN:
+        return False
+    _, _, domain = value.partition("@")
+    return "." in domain and not domain.endswith(".")
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _as_aware(value: datetime) -> datetime:
+    """Treat naive datetimes (SQLite) as UTC for comparison."""
+    return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+
+def _invite_link(token: str) -> str:
+    base = (settings.frontend_url or "").rstrip("/")
+    return f"{base}/app/invite?token={token}"
+
+
+async def _send_invite_email_safe(
+    *, to: str, group_name: str, token: str
+) -> None:
+    """BackgroundTask: send the invite email, never raise."""
+    try:
+        link = _invite_link(token)
+        await send_email(
+            to=[to],
+            subject=f"[HOT] You've been invited to {group_name}",
+            text_body=(
+                f"You have been invited to join the organization "
+                f"'{group_name}' on HOT.\n\n"
+                f"Accept the invitation here: {link}\n\n"
+                "If you don't have a HOT account yet, sign up first and then "
+                "open the link above."
+            ),
+        )
+        logger.info("Invitation email sent to %s for group %s", to, group_name)
+    except Exception:
+        logger.exception("Failed to send invitation email to %s", to)
+
+
+# --- Group-side invitation management (owner/manager) ----------------------
+
+
+@router.post(
+    "/{group_id}/invitations",
+    response_model=InvitationResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_invitation(
+    group_id: str,
+    payload: InvitationCreate,
+    user: CurrentUser,
+    db: DB,
+    background_tasks: BackgroundTasks,
+) -> InvitationResponse:
+    """Invite a user to an organization by email (owner/manager)."""
+    group = await groups_service.load_group_or_404(db, group_id)
+    await groups_service.require_role(db, group, user, "manager")
+    if group.type != "organization":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only organizations use invitations",
+        )
+    if group.status != "approved":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Approve the organization before inviting members",
+        )
+    email = payload.email.strip().lower()
+    if not _looks_like_email(email):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Invalid email address",
+        )
+
+    existing = await db.execute(
+        select(GroupInvitation).where(
+            GroupInvitation.group_id == group_id,
+            GroupInvitation.email == email,
+            GroupInvitation.status == "pending",
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A pending invitation already exists for this email",
+        )
+
+    invitation = GroupInvitation(
+        group_id=group_id,
+        email=email,
+        role=payload.role,
+        token=secrets.token_urlsafe(32),
+        invited_by=user.id,
+        expires_at=_now() + timedelta(days=_INVITE_TTL_DAYS),
+    )
+    db.add(invitation)
+    await db.commit()
+    await db.refresh(invitation)
+
+    background_tasks.add_task(
+        _send_invite_email_safe,
+        to=email,
+        group_name=group.name,
+        token=invitation.token,
+    )
+    response = InvitationResponse.model_validate(invitation, from_attributes=True)
+    response.recipient_exists = await hanko_lookup.email_has_account(email)
+    return response
+
+
+@router.get("/{group_id}/invitations", response_model=list[InvitationResponse])
+async def list_invitations(
+    group_id: str, user: CurrentUser, db: DB
+) -> list[InvitationResponse]:
+    """List pending invitations for an organization (owner/manager)."""
+    group = await groups_service.load_group_or_404(db, group_id)
+    await groups_service.require_role(db, group, user, "manager")
+    result = await db.execute(
+        select(GroupInvitation)
+        .where(
+            GroupInvitation.group_id == group_id,
+            GroupInvitation.status == "pending",
+        )
+        .order_by(GroupInvitation.created_at.desc())
+    )
+    return [
+        InvitationResponse.model_validate(inv, from_attributes=True)
+        for inv in result.scalars().all()
+    ]
+
+
+@router.delete(
+    "/{group_id}/invitations/{invitation_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def revoke_invitation(
+    group_id: str, invitation_id: str, user: CurrentUser, db: DB
+) -> Response:
+    """Revoke a pending invitation (owner/manager)."""
+    group = await groups_service.load_group_or_404(db, group_id)
+    await groups_service.require_role(db, group, user, "manager")
+    result = await db.execute(
+        select(GroupInvitation).where(
+            GroupInvitation.id == invitation_id,
+            GroupInvitation.group_id == group_id,
+        )
+    )
+    invitation = result.scalar_one_or_none()
+    if invitation is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found"
+        )
+    invitation.status = "revoked"
+    invitation.responded_at = _now()
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# --- Recipient-side (the invited user) -------------------------------------
+
+
+async def _get_pending_invitation(
+    db: AsyncSession, token: str
+) -> GroupInvitation:
+    result = await db.execute(
+        select(GroupInvitation).where(GroupInvitation.token == token)
+    )
+    invitation = result.scalar_one_or_none()
+    if invitation is None or invitation.status != "pending":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found"
+        )
+    return invitation
+
+
+@me_router.get("", response_model=list[MyInvitationResponse])
+async def list_my_invitations(
+    user: CurrentUser, db: DB
+) -> list[MyInvitationResponse]:
+    """List the current user's pending, unexpired invitations."""
+    if not user.email:
+        return []
+    email = user.email.strip().lower()
+    result = await db.execute(
+        select(GroupInvitation, Group)
+        .join(Group, Group.id == GroupInvitation.group_id)
+        .where(
+            GroupInvitation.email == email,
+            GroupInvitation.status == "pending",
+        )
+        .order_by(GroupInvitation.created_at.desc())
+    )
+    now = _now()
+    items: list[MyInvitationResponse] = []
+    for invitation, group in result.all():
+        if _as_aware(invitation.expires_at) < now:
+            continue
+        items.append(
+            MyInvitationResponse(
+                id=invitation.id,
+                group_id=invitation.group_id,
+                email=invitation.email,
+                role=invitation.role,
+                status=invitation.status,
+                invited_by=invitation.invited_by,
+                created_at=invitation.created_at,
+                expires_at=invitation.expires_at,
+                token=invitation.token,
+                group_name=group.name,
+                group_type=group.type,
+            )
+        )
+    return items
+
+
+@me_router.post("/{token}/accept", status_code=status.HTTP_204_NO_CONTENT)
+async def accept_invitation(token: str, user: CurrentUser, db: DB) -> Response:
+    """Accept an invitation, creating the membership."""
+    invitation = await _get_pending_invitation(db, token)
+    if not user.email or user.email.strip().lower() != invitation.email:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This invitation was sent to a different email",
+        )
+    if _as_aware(invitation.expires_at) < _now():
+        invitation.status = "expired"
+        await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE, detail="Invitation has expired"
+        )
+
+    existing = await groups_service.get_membership(
+        db, invitation.group_id, user.id
+    )
+    if existing is None:
+        db.add(
+            GroupMembership(
+                group_id=invitation.group_id,
+                hanko_user_id=user.id,
+                role=invitation.role,
+            )
+        )
+    invitation.status = "accepted"
+    invitation.invited_hanko_user_id = user.id
+    invitation.responded_at = _now()
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@me_router.post("/{token}/decline", status_code=status.HTTP_204_NO_CONTENT)
+async def decline_invitation(token: str, user: CurrentUser, db: DB) -> Response:
+    """Decline an invitation."""
+    invitation = await _get_pending_invitation(db, token)
+    if not user.email or user.email.strip().lower() != invitation.email:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This invitation was sent to a different email",
+        )
+    invitation.status = "declined"
+    invitation.responded_at = _now()
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/routes/organizations_admin.py
+++ b/backend/app/api/routes/organizations_admin.py
@@ -139,12 +139,8 @@ async def list_organizations(
         .limit(page_size)
         .offset((page - 1) * page_size)
     )
-    items = [
-        groups_service.serialize_group(g) for g in result.scalars().all()
-    ]
-    return GroupListResponse(
-        items=items, total=total, page=page, page_size=page_size
-    )
+    items = [groups_service.serialize_group(g) for g in result.scalars().all()]
+    return GroupListResponse(items=items, total=total, page=page, page_size=page_size)
 
 
 async def _load_org_or_404(db: AsyncSession, group_id: str) -> Group:
@@ -157,7 +153,9 @@ async def _load_org_or_404(db: AsyncSession, group_id: str) -> Group:
     return group
 
 
-@router.post("/organizations/{group_id}/approve", status_code=status.HTTP_204_NO_CONTENT)
+@router.post(
+    "/organizations/{group_id}/approve", status_code=status.HTTP_204_NO_CONTENT
+)
 async def approve_organization(
     group_id: str,
     admin: AccountManagerUser,
@@ -184,13 +182,13 @@ async def reject_organization(
     group = await _load_org_or_404(db, group_id)
     group.status = "rejected"
     await db.commit()
-    await _notify_owner(
-        background_tasks, group, approved=False, reason=payload.reason
-    )
+    await _notify_owner(background_tasks, group, approved=False, reason=payload.reason)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@router.post("/organizations/{group_id}/approve-name", status_code=status.HTTP_204_NO_CONTENT)
+@router.post(
+    "/organizations/{group_id}/approve-name", status_code=status.HTTP_204_NO_CONTENT
+)
 async def approve_name_change(
     group_id: str, admin: AccountManagerUser, db: DB
 ) -> Response:
@@ -223,9 +221,7 @@ async def set_organization_name(
     """Set an organization's name directly (account manager)."""
     group = await _load_org_or_404(db, group_id)
     group.name = payload.name
-    group.slug = await groups_service.generate_unique_slug(
-        db, group.type, payload.name
-    )
+    group.slug = await groups_service.generate_unique_slug(db, group.type, payload.name)
     group.pending_name = None
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
@@ -254,27 +250,23 @@ async def grant_account_manager(
 ) -> Response:
     """Grant the account-manager role to a user."""
     existing = await db.execute(
-        select(AccountManager).where(
-            AccountManager.hanko_user_id == hanko_user_id
-        )
+        select(AccountManager).where(AccountManager.hanko_user_id == hanko_user_id)
     )
     if existing.scalar_one_or_none() is None:
-        db.add(
-            AccountManager(hanko_user_id=hanko_user_id, granted_by=admin.id)
-        )
+        db.add(AccountManager(hanko_user_id=hanko_user_id, granted_by=admin.id))
         await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@router.delete("/account-managers/{hanko_user_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/account-managers/{hanko_user_id}", status_code=status.HTTP_204_NO_CONTENT
+)
 async def revoke_account_manager(
     hanko_user_id: str, admin: AdminUser, db: DB
 ) -> Response:
     """Revoke the account-manager role from a user."""
     result = await db.execute(
-        select(AccountManager).where(
-            AccountManager.hanko_user_id == hanko_user_id
-        )
+        select(AccountManager).where(AccountManager.hanko_user_id == hanko_user_id)
     )
     am = result.scalar_one_or_none()
     if am is not None:

--- a/backend/app/api/routes/organizations_admin.py
+++ b/backend/app/api/routes/organizations_admin.py
@@ -1,0 +1,283 @@
+"""Account-manager and administrator endpoints.
+
+Account managers approve/reject organizations and moderate their names.
+Administrators (env allowlist) grant/revoke the account-manager role.
+"""
+
+import logging
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    HTTPException,
+    Query,
+    Response,
+    status,
+)
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.authz import (
+    DB as _DB,
+)
+from app.core.authz import (
+    AccountManagerUser,
+    AdminUser,
+    get_roles,
+)
+from app.core.authz import (
+    CurrentUser as _CurrentUser,
+)
+from app.core.config import settings
+from app.db.models import AccountManager, Group
+from app.schemas.groups import GroupListResponse
+from app.services import groups_service, hanko_lookup
+from app.services.email import send_email
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/admin", tags=["Organizations Admin"])
+me_router = APIRouter(prefix="/api/me", tags=["Me"])
+
+CurrentUser = _CurrentUser
+DB = _DB
+
+
+def _org_link(group_id: str) -> str:
+    base = (settings.frontend_url or "").rstrip("/")
+    return f"{base}/app/organizations/{group_id}"
+
+
+async def _send_owner_email_safe(*, to: str, subject: str, body: str) -> None:
+    """BackgroundTask: notify an org owner, never raise."""
+    try:
+        await send_email(to=[to], subject=subject, text_body=body)
+    except Exception:
+        logger.exception("Failed to send org moderation email to %s", to)
+
+
+async def _notify_owner(
+    background_tasks: BackgroundTasks,
+    group: Group,
+    *,
+    approved: bool,
+    reason: str | None = None,
+) -> None:
+    """Email the org's owner about an approval/rejection decision."""
+    email = await hanko_lookup.user_id_to_email(group.created_by)
+    if not email:
+        return
+    if approved:
+        subject = f"[HOT] Your organization {group.name} was approved"
+        body = (
+            f"Good news! Your organization '{group.name}' has been approved.\n\n"
+            f"You can now invite members from its page:\n{_org_link(group.id)}"
+        )
+    else:
+        subject = f"[HOT] Your organization {group.name} was not approved"
+        body = f"Your organization request '{group.name}' was not approved."
+        if reason:
+            body += f"\n\nReason: {reason}"
+    background_tasks.add_task(
+        _send_owner_email_safe, to=email, subject=subject, body=body
+    )
+
+
+class RejectRequest(BaseModel):
+    """Optional reason when rejecting an organization."""
+
+    reason: str | None = None
+
+
+class AccountManagerResponse(BaseModel):
+    """An account-manager grant record."""
+
+    hanko_user_id: str
+    granted_by: str
+    granted_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+# --- Roles (for the frontend to gate the Users/Organizations tabs) ---------
+
+
+@me_router.get("/roles")
+async def get_my_roles(user: CurrentUser, db: DB) -> dict[str, bool]:
+    """Return the current user's platform roles."""
+    return await get_roles(user, db)
+
+
+# --- Organization moderation (account managers) ----------------------------
+
+
+@router.get("/organizations", response_model=GroupListResponse)
+async def list_organizations(
+    admin: AccountManagerUser,
+    db: DB,
+    status_filter: Annotated[str | None, Query(alias="status")] = None,
+    page: Annotated[int, Query(ge=1)] = 1,
+    page_size: Annotated[int, Query(ge=1, le=100)] = 50,
+) -> GroupListResponse:
+    """List organizations for moderation (optionally filtered by status)."""
+    conditions = [Group.type == "organization"]
+    if status_filter:
+        conditions.append(Group.status == status_filter)
+
+    total_result = await db.execute(
+        select(func.count()).select_from(Group).where(*conditions)
+    )
+    total = int(total_result.scalar_one())
+
+    result = await db.execute(
+        select(Group)
+        .where(*conditions)
+        .order_by(Group.created_at.desc())
+        .limit(page_size)
+        .offset((page - 1) * page_size)
+    )
+    items = [
+        groups_service.serialize_group(g) for g in result.scalars().all()
+    ]
+    return GroupListResponse(
+        items=items, total=total, page=page, page_size=page_size
+    )
+
+
+async def _load_org_or_404(db: AsyncSession, group_id: str) -> Group:
+    group = await groups_service.get_group(db, group_id)
+    if group is None or group.type != "organization":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization not found",
+        )
+    return group
+
+
+@router.post("/organizations/{group_id}/approve", status_code=status.HTTP_204_NO_CONTENT)
+async def approve_organization(
+    group_id: str,
+    admin: AccountManagerUser,
+    db: DB,
+    background_tasks: BackgroundTasks,
+) -> Response:
+    """Approve a pending (or previously rejected) organization."""
+    group = await _load_org_or_404(db, group_id)
+    group.status = "approved"
+    await db.commit()
+    await _notify_owner(background_tasks, group, approved=True)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/organizations/{group_id}/reject", status_code=status.HTTP_204_NO_CONTENT)
+async def reject_organization(
+    group_id: str,
+    payload: RejectRequest,
+    admin: AccountManagerUser,
+    db: DB,
+    background_tasks: BackgroundTasks,
+) -> Response:
+    """Reject an organization request."""
+    group = await _load_org_or_404(db, group_id)
+    group.status = "rejected"
+    await db.commit()
+    await _notify_owner(
+        background_tasks, group, approved=False, reason=payload.reason
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/organizations/{group_id}/approve-name", status_code=status.HTTP_204_NO_CONTENT)
+async def approve_name_change(
+    group_id: str, admin: AccountManagerUser, db: DB
+) -> Response:
+    """Apply an organization's pending name change and regenerate its slug."""
+    group = await _load_org_or_404(db, group_id)
+    if not group.pending_name:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No pending name change",
+        )
+    group.name = group.pending_name
+    group.slug = await groups_service.generate_unique_slug(
+        db, group.type, group.pending_name
+    )
+    group.pending_name = None
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+class NamePayload(BaseModel):
+    """Direct name override by an account manager."""
+
+    name: str
+
+
+@router.patch("/organizations/{group_id}/name", status_code=status.HTTP_204_NO_CONTENT)
+async def set_organization_name(
+    group_id: str, payload: NamePayload, admin: AccountManagerUser, db: DB
+) -> Response:
+    """Set an organization's name directly (account manager)."""
+    group = await _load_org_or_404(db, group_id)
+    group.name = payload.name
+    group.slug = await groups_service.generate_unique_slug(
+        db, group.type, payload.name
+    )
+    group.pending_name = None
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# --- Account-manager role management (administrators only) -----------------
+
+
+@router.get("/account-managers", response_model=list[AccountManagerResponse])
+async def list_account_managers(
+    admin: AdminUser, db: DB
+) -> list[AccountManagerResponse]:
+    """List all account managers."""
+    result = await db.execute(
+        select(AccountManager).order_by(AccountManager.granted_at.desc())
+    )
+    return [
+        AccountManagerResponse.model_validate(am, from_attributes=True)
+        for am in result.scalars().all()
+    ]
+
+
+@router.put("/account-managers/{hanko_user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def grant_account_manager(
+    hanko_user_id: str, admin: AdminUser, db: DB
+) -> Response:
+    """Grant the account-manager role to a user."""
+    existing = await db.execute(
+        select(AccountManager).where(
+            AccountManager.hanko_user_id == hanko_user_id
+        )
+    )
+    if existing.scalar_one_or_none() is None:
+        db.add(
+            AccountManager(hanko_user_id=hanko_user_id, granted_by=admin.id)
+        )
+        await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.delete("/account-managers/{hanko_user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_account_manager(
+    hanko_user_id: str, admin: AdminUser, db: DB
+) -> Response:
+    """Revoke the account-manager role from a user."""
+    result = await db.execute(
+        select(AccountManager).where(
+            AccountManager.hanko_user_id == hanko_user_id
+        )
+    )
+    am = result.scalar_one_or_none()
+    if am is not None:
+        await db.delete(am)
+        await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/routes/public.py
+++ b/backend/app/api/routes/public.py
@@ -33,9 +33,7 @@ async def _public_group_by_slug(
     result = await db.execute(select(Group).where(*conditions))
     group = result.scalar_one_or_none()
     if group is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
     return group
 
 
@@ -70,32 +68,24 @@ async def _serialize_public_group(
 @router.get("/org/{slug}", response_model=PublicGroupResponse)
 async def public_organization(slug: str, db: DB) -> PublicGroupResponse:
     """Public profile of an approved, public organization."""
-    group = await _public_group_by_slug(
-        db, "organization", slug, require_approved=True
-    )
+    group = await _public_group_by_slug(db, "organization", slug, require_approved=True)
     return await _serialize_public_group(db, group)
 
 
 @router.get("/team/{slug}", response_model=PublicGroupResponse)
 async def public_team(slug: str, db: DB) -> PublicGroupResponse:
     """Public profile of a public team."""
-    group = await _public_group_by_slug(
-        db, "team", slug, require_approved=False
-    )
+    group = await _public_group_by_slug(db, "team", slug, require_approved=False)
     return await _serialize_public_group(db, group)
 
 
 @router.get("/user/{slug}", response_model=PublicUserResponse)
 async def public_user(slug: str, db: DB) -> PublicUserResponse:
     """Public profile of a user by slug."""
-    result = await db.execute(
-        select(UserProfile).where(UserProfile.slug == slug)
-    )
+    result = await db.execute(select(UserProfile).where(UserProfile.slug == slug))
     profile = result.scalar_one_or_none()
     if profile is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
     return PublicUserResponse(
         slug=profile.slug,
         first_name=profile.first_name,

--- a/backend/app/api/routes/public.py
+++ b/backend/app/api/routes/public.py
@@ -1,0 +1,104 @@
+"""Public profiles for organizations, teams and users (no auth).
+
+Rendered by portal in a later stage. Only public, approved entities are
+exposed. Data lives here in login; portal fetches it by slug.
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_db
+from app.db.models import Group, GroupMembership, UserProfile
+from app.schemas.groups import PublicGroupResponse, PublicUserResponse
+from app.services import groups_service
+
+router = APIRouter(prefix="/api/public", tags=["Public Profiles"])
+
+DB = Annotated[AsyncSession, Depends(get_db)]
+
+
+async def _public_group_by_slug(
+    db: AsyncSession, group_type: str, slug: str, *, require_approved: bool
+) -> Group:
+    conditions = [
+        Group.type == group_type,
+        Group.slug == slug,
+        Group.is_public.is_(True),
+    ]
+    if require_approved:
+        conditions.append(Group.status == "approved")
+    result = await db.execute(select(Group).where(*conditions))
+    group = result.scalar_one_or_none()
+    if group is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Not found"
+        )
+    return group
+
+
+async def _serialize_public_group(
+    db: AsyncSession, group: Group
+) -> PublicGroupResponse:
+    members_result = await db.execute(
+        select(func.count())
+        .select_from(GroupMembership)
+        .where(GroupMembership.group_id == group.id)
+    )
+    return PublicGroupResponse(
+        type=group.type,
+        name=group.name,
+        slug=group.slug,
+        description=group.description,
+        website=group.website,
+        avatar_url=(
+            groups_service.image_url(group.id, "avatar", group.avatar_key)
+            if group.avatar_key
+            else None
+        ),
+        banner_url=(
+            groups_service.image_url(group.id, "banner", group.banner_key)
+            if group.banner_key
+            else None
+        ),
+        members_count=int(members_result.scalar_one()),
+    )
+
+
+@router.get("/org/{slug}", response_model=PublicGroupResponse)
+async def public_organization(slug: str, db: DB) -> PublicGroupResponse:
+    """Public profile of an approved, public organization."""
+    group = await _public_group_by_slug(
+        db, "organization", slug, require_approved=True
+    )
+    return await _serialize_public_group(db, group)
+
+
+@router.get("/team/{slug}", response_model=PublicGroupResponse)
+async def public_team(slug: str, db: DB) -> PublicGroupResponse:
+    """Public profile of a public team."""
+    group = await _public_group_by_slug(
+        db, "team", slug, require_approved=False
+    )
+    return await _serialize_public_group(db, group)
+
+
+@router.get("/user/{slug}", response_model=PublicUserResponse)
+async def public_user(slug: str, db: DB) -> PublicUserResponse:
+    """Public profile of a user by slug."""
+    result = await db.execute(
+        select(UserProfile).where(UserProfile.slug == slug)
+    )
+    profile = result.scalar_one_or_none()
+    if profile is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Not found"
+        )
+    return PublicUserResponse(
+        slug=profile.slug,
+        first_name=profile.first_name,
+        last_name=profile.last_name,
+        picture_url=profile.picture_url,
+    )

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -32,17 +32,10 @@ async def lookup_user(
         return {"exists": False}
 
     result = await db.execute(
-        select(UserProfile).where(
-            UserProfile.hanko_user_id == hanko_user_id
-        )
+        select(UserProfile).where(UserProfile.hanko_user_id == hanko_user_id)
     )
     profile = result.scalar_one_or_none()
     name = None
     if profile:
-        name = (
-            " ".join(
-                p for p in (profile.first_name, profile.last_name) if p
-            )
-            or None
-        )
+        name = " ".join(p for p in (profile.first_name, profile.last_name) if p) or None
     return {"exists": True, "hanko_user_id": hanko_user_id, "name": name}

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,0 +1,48 @@
+"""User lookup by email (for adding members to teams).
+
+Lets the team UI verify an email as it's typed, so members are added by email
+instead of by raw Hanko user id.
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+from hotosm_auth.models import HankoUser
+from hotosm_auth_fastapi import get_current_user
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_db
+from app.db.models import UserProfile
+from app.services import hanko_lookup
+
+router = APIRouter(prefix="/api/users", tags=["Users"])
+
+CurrentUser = Annotated[HankoUser, Depends(get_current_user)]
+DB = Annotated[AsyncSession, Depends(get_db)]
+
+
+@router.get("/lookup")
+async def lookup_user(
+    user: CurrentUser, db: DB, email: Annotated[str, Query()]
+) -> dict:
+    """Resolve an email to a HOT account. ``{exists, hanko_user_id?, name?}``."""
+    hanko_user_id = await hanko_lookup.email_to_user_id(email.strip().lower())
+    if hanko_user_id is None:
+        return {"exists": False}
+
+    result = await db.execute(
+        select(UserProfile).where(
+            UserProfile.hanko_user_id == hanko_user_id
+        )
+    )
+    profile = result.scalar_one_or_none()
+    name = None
+    if profile:
+        name = (
+            " ".join(
+                p for p in (profile.first_name, profile.last_name) if p
+            )
+            or None
+        )
+    return {"exists": True, "hanko_user_id": hanko_user_id, "name": name}

--- a/backend/app/core/authz.py
+++ b/backend/app/core/authz.py
@@ -1,0 +1,89 @@
+"""Authorization helpers for platform-level roles.
+
+Two platform roles exist:
+
+* **Administrator** — configured via the ``ADMIN_EMAILS`` env var (email
+  allowlist). Mirrors ``require_admin`` in ``api/routes/admin.py``.
+* **Account Manager** — persisted in the ``account_managers`` table, assigned by
+  an administrator. Administrators implicitly hold this role.
+
+These are distinct from group member roles (owner/manager/member), which govern
+a single group rather than the whole platform.
+"""
+
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, status
+from hotosm_auth.models import HankoUser
+from hotosm_auth_fastapi import get_current_user
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.db.database import get_db
+from app.db.models import AccountManager
+
+CurrentUser = Annotated[HankoUser, Depends(get_current_user)]
+DB = Annotated[AsyncSession, Depends(get_db)]
+
+
+def is_admin(user: HankoUser) -> bool:
+    """Return True if the user's email is in the admin allowlist."""
+    if not user.email:
+        return False
+    return user.email.lower() in settings.admin_email_list
+
+
+async def is_account_manager(user: HankoUser, db: AsyncSession) -> bool:
+    """Return True if the user is an account manager (admins are implicit)."""
+    if is_admin(user):
+        return True
+    result = await db.execute(
+        select(AccountManager.hanko_user_id).where(
+            AccountManager.hanko_user_id == user.id
+        )
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def get_roles(user: HankoUser, db: AsyncSession) -> dict[str, bool]:
+    """Resolve the platform roles of a user in a single call."""
+    admin = is_admin(user)
+    return {
+        "is_admin": admin,
+        # Admin implies account manager; avoid a DB hit when already admin.
+        "is_account_manager": admin or await is_account_manager(user, db),
+    }
+
+
+async def require_account_manager(user: CurrentUser, db: DB) -> HankoUser:
+    """Require the current user to be an account manager (or admin)."""
+    if not await is_account_manager(user, db):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Account manager access required",
+        )
+    return user
+
+
+async def require_admin(user: CurrentUser) -> HankoUser:
+    """Require the current user to be an administrator (env allowlist).
+
+    Kept here (in addition to ``api/routes/admin.py``) so group-domain routers
+    can depend on it without importing the admin proxy module.
+    """
+    if not settings.admin_email_list:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access not configured",
+        )
+    if not is_admin(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+    return user
+
+
+AccountManagerUser = Annotated[HankoUser, Depends(require_account_manager)]
+AdminUser = Annotated[HankoUser, Depends(require_admin)]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -56,6 +56,19 @@ class Settings(BaseSettings):
     smtp_from_address: str = ""
     smtp_starttls: bool = True
 
+    # Public base URLs of this login deployment (already provided as env vars in
+    # docker-compose). backend_url serves /api/* (image endpoints); frontend_url
+    # serves /app/* (the invitation accept page). Empty => relative URLs.
+    backend_url: str = ""
+    frontend_url: str = ""
+
+    # S3/MinIO storage for group avatar/banner images. When unset, images fall
+    # back to the local filesystem (fine for dev without object storage).
+    s3_endpoint_url: str | None = None
+    s3_bucket_name: str | None = None
+    s3_access_key: str | None = None
+    s3_secret_key: str | None = None
+
     @property
     def app_urls(self) -> dict[str, str]:
         """Get app URLs as a dictionary."""

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,6 +1,22 @@
 """Database module for login backend."""
 
 from app.db.database import Base, get_db
-from app.db.models import UserApiToken, UserProfile
+from app.db.models import (
+    AccountManager,
+    Group,
+    GroupInvitation,
+    GroupMembership,
+    UserApiToken,
+    UserProfile,
+)
 
-__all__ = ["Base", "get_db", "UserApiToken", "UserProfile"]
+__all__ = [
+    "Base",
+    "get_db",
+    "AccountManager",
+    "Group",
+    "GroupInvitation",
+    "GroupMembership",
+    "UserApiToken",
+    "UserProfile",
+]

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -3,10 +3,28 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import JSON, DateTime, ForeignKey, String, Text, Uuid, func
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+    Uuid,
+    func,
+    text,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.database import Base
+
+
+def _uuid_str() -> str:
+    """Generate a UUID4 as a string (portable across Postgres and SQLite)."""
+    return str(uuid.uuid4())
 
 
 class UserProfile(Base):
@@ -26,6 +44,9 @@ class UserProfile(Base):
     last_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
     picture_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     language: Mapped[str] = mapped_column(String(10), default="en", nullable=False)
+
+    # Public profile slug (/user/{slug}); generated lazily from username/email.
+    slug: Mapped[str | None] = mapped_column(String(80), nullable=True, unique=True)
 
     # OSM connection (cached from OAuth)
     osm_user_id: Mapped[int | None] = mapped_column(nullable=True)
@@ -82,3 +103,202 @@ class UserApiToken(Base):
     def __repr__(self) -> str:
         """Return short debug representation for logging."""
         return f"<UserApiToken(user={self.hanko_user_id[:8]}..., app={self.app})>"
+
+
+# --- Teams & Organizations -------------------------------------------------
+#
+# A single ``groups`` table models both informal teams and official
+# organizations, discriminated by ``type``. User references are stored as bare
+# ``hanko_user_id`` strings (no FK to user_profiles): a member, invitee or
+# account manager may exist in Hanko without ever having created a local
+# profile row. Foreign keys are used only between the group-domain tables.
+
+GROUP_TYPES = ("team", "organization")
+GROUP_STATUSES = ("pending", "approved", "rejected")
+MEMBER_ROLES = ("owner", "manager", "member")
+INVITATION_STATUSES = ("pending", "accepted", "declined", "expired", "revoked")
+
+
+class Group(Base):
+    """A team (informal) or organization (official, needs approval)."""
+
+    __tablename__ = "groups"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid_str)
+    type: Mapped[str] = mapped_column(String(20), nullable=False)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    slug: Mapped[str] = mapped_column(String(80), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Organization-only fields (nullable; enforced by business rules per type)
+    contact_email: Mapped[str | None] = mapped_column(String(320), nullable=True)
+    website: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    avatar_key: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    banner_key: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+    # Teams are always 'approved'; orgs move pending -> approved/rejected.
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="approved"
+    )
+    # Proposed name change awaiting account-manager approval (orgs only).
+    pending_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    # Whether the group exposes a public profile in portal (opt-in).
+    is_public: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
+    created_by: Mapped[str] = mapped_column(String(36), nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), nullable=True
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "type IN ('team', 'organization')", name="ck_groups_type"
+        ),
+        CheckConstraint(
+            "status IN ('pending', 'approved', 'rejected')",
+            name="ck_groups_status",
+        ),
+        # Slug is unique per type: /org/{slug} and /team/{slug} are separate
+        # namespaces, so the same slug may exist as both an org and a team.
+        UniqueConstraint("type", "slug", name="ux_groups_type_slug"),
+        Index("ix_groups_type_status", "type", "status"),
+        Index("ix_groups_created_by", "created_by"),
+    )
+
+    def __repr__(self) -> str:
+        """Return short debug representation for logging."""
+        return f"<Group(id={self.id[:8]}..., type={self.type}, slug={self.slug})>"
+
+
+class GroupMembership(Base):
+    """A user's membership and role within a group.
+
+    Roles govern group administration inside login only (not plan permissions,
+    which look at membership rather than role). Hierarchy: owner > manager >
+    member. Exactly one owner per group (enforced by business rules).
+    """
+
+    __tablename__ = "group_memberships"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid_str)
+    group_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("groups.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    hanko_user_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    role: Mapped[str] = mapped_column(String(20), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "role IN ('owner', 'manager', 'member')",
+            name="ck_group_memberships_role",
+        ),
+        UniqueConstraint(
+            "group_id", "hanko_user_id", name="ux_group_memberships_group_user"
+        ),
+        Index("ix_group_memberships_user", "hanko_user_id"),
+        Index("ix_group_memberships_group", "group_id"),
+    )
+
+    def __repr__(self) -> str:
+        """Return short debug representation for logging."""
+        return (
+            f"<GroupMembership(group={self.group_id[:8]}..., "
+            f"user={self.hanko_user_id[:8]}..., role={self.role})>"
+        )
+
+
+class GroupInvitation(Base):
+    """An email-anchored invitation to join an organization.
+
+    Anchored on ``email`` (not hanko_user_id) because the invitee may not have
+    an account yet: the hanko_user_id is resolved only when they accept.
+    Teams do not use invitations (members are added directly).
+    """
+
+    __tablename__ = "group_invitations"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid_str)
+    group_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("groups.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    email: Mapped[str] = mapped_column(String(320), nullable=False)
+    role: Mapped[str] = mapped_column(String(20), nullable=False, default="member")
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="pending"
+    )
+    token: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    invited_by: Mapped[str] = mapped_column(String(36), nullable=False)
+    invited_hanko_user_id: Mapped[str | None] = mapped_column(
+        String(36), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    responded_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('pending', 'accepted', 'declined', 'expired', 'revoked')",
+            name="ck_group_invitations_status",
+        ),
+        CheckConstraint(
+            "role IN ('owner', 'manager', 'member')",
+            name="ck_group_invitations_role",
+        ),
+        # At most one live (pending) invitation per (group, email). Partial
+        # unique index is supported by both Postgres and SQLite (>= 3.8).
+        Index(
+            "ux_group_invitations_pending",
+            "group_id",
+            "email",
+            unique=True,
+            postgresql_where=text("status = 'pending'"),
+            sqlite_where=text("status = 'pending'"),
+        ),
+        Index("ix_group_invitations_email", "email"),
+        Index("ix_group_invitations_group", "group_id"),
+    )
+
+    def __repr__(self) -> str:
+        """Return short debug representation for logging."""
+        return (
+            f"<GroupInvitation(group={self.group_id[:8]}..., "
+            f"email={self.email}, status={self.status})>"
+        )
+
+
+class AccountManager(Base):
+    """Platform-level Account Manager role.
+
+    Assigned by an Administrator (ADMIN_EMAILS). Administrators implicitly have
+    this role in code, so they are not persisted here.
+    """
+
+    __tablename__ = "account_managers"
+
+    hanko_user_id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    granted_by: Mapped[str] = mapped_column(String(36), nullable=False)
+    granted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    def __repr__(self) -> str:
+        """Return short debug representation for logging."""
+        return f"<AccountManager(user={self.hanko_user_id[:8]}...)>"

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -137,15 +137,11 @@ class Group(Base):
     banner_key: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
     # Teams are always 'approved'; orgs move pending -> approved/rejected.
-    status: Mapped[str] = mapped_column(
-        String(20), nullable=False, default="approved"
-    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="approved")
     # Proposed name change awaiting account-manager approval (orgs only).
     pending_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
     # Whether the group exposes a public profile in portal (opt-in).
-    is_public: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False
-    )
+    is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     created_by: Mapped[str] = mapped_column(String(36), nullable=False)
 
     created_at: Mapped[datetime] = mapped_column(
@@ -156,9 +152,7 @@ class Group(Base):
     )
 
     __table_args__ = (
-        CheckConstraint(
-            "type IN ('team', 'organization')", name="ck_groups_type"
-        ),
+        CheckConstraint("type IN ('team', 'organization')", name="ck_groups_type"),
         CheckConstraint(
             "status IN ('pending', 'approved', 'rejected')",
             name="ck_groups_status",
@@ -235,14 +229,10 @@ class GroupInvitation(Base):
     )
     email: Mapped[str] = mapped_column(String(320), nullable=False)
     role: Mapped[str] = mapped_column(String(20), nullable=False, default="member")
-    status: Mapped[str] = mapped_column(
-        String(20), nullable=False, default="pending"
-    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
     token: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
     invited_by: Mapped[str] = mapped_column(String(36), nullable=False)
-    invited_hanko_user_id: Mapped[str | None] = mapped_column(
-        String(36), nullable=True
-    )
+    invited_hanko_user_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,12 @@ from app.__version__ import __version__
 from app.api.routes import admin as admin_routes
 from app.api.routes import api_token as api_token_routes
 from app.api.routes import data_deletion as data_deletion_routes
+from app.api.routes import groups as groups_routes
+from app.api.routes import invitations as invitations_routes
+from app.api.routes import organizations_admin as organizations_admin_routes
 from app.api.routes import profile as profile_routes
+from app.api.routes import public as public_routes
+from app.api.routes import users as users_routes
 from app.schemas.auth import UserInfoResponse
 
 
@@ -107,13 +112,11 @@ auth_config = AuthConfig.from_env()
 
 async def _local_pat_resolver(token_hash: str, app_name: str):
     """Resolve a PAT directly from the login DB (no HTTP call to self)."""
-    from datetime import datetime, timezone
-
+    from hotosm_auth.models import HankoUser
     from sqlalchemy import select
 
     from app.db.database import async_session_maker
     from app.db.models import UserApiToken, UserProfile
-    from hotosm_auth.models import HankoUser
 
     async with async_session_maker() as session:
         result = await session.execute(
@@ -164,6 +167,13 @@ app.include_router(profile_routes.router)
 app.include_router(api_token_routes.router)
 app.include_router(api_token_routes.internal_router)
 app.include_router(data_deletion_routes.router)
+app.include_router(groups_routes.router)
+app.include_router(invitations_routes.router)
+app.include_router(invitations_routes.me_router)
+app.include_router(organizations_admin_routes.router)
+app.include_router(organizations_admin_routes.me_router)
+app.include_router(public_routes.router)
+app.include_router(users_routes.router)
 
 
 @app.get("/me", response_model=UserInfoResponse)

--- a/backend/app/schemas/groups.py
+++ b/backend/app/schemas/groups.py
@@ -1,0 +1,210 @@
+"""Schemas for teams, organizations, members and invitations.
+
+This is the public contract consumed by portal (and later ChatMap), so field
+names and shapes are kept stable and explicit.
+"""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+GroupType = Literal["team", "organization"]
+GroupStatus = Literal["pending", "approved", "rejected"]
+MemberRole = Literal["owner", "manager", "member"]
+InvitationStatus = Literal["pending", "accepted", "declined", "expired", "revoked"]
+
+
+# --- Groups ----------------------------------------------------------------
+
+
+class GroupCreate(BaseModel):
+    """Request to create a team or organization."""
+
+    type: GroupType
+    name: str = Field(..., min_length=1, max_length=200)
+    description: str | None = Field(None, max_length=5000)
+    contact_email: str | None = Field(None, max_length=320)
+    website: str | None = Field(None, max_length=500)
+    # Teams may seed members on creation by email (added directly, no invite).
+    member_emails: list[str] | None = None
+
+
+class GroupUpdate(BaseModel):
+    """Editable group details. The ``name`` is NOT editable here.
+
+    For organizations, changing the name goes through ``/name-change`` and
+    requires account-manager approval.
+    """
+
+    description: str | None = Field(None, max_length=5000)
+    contact_email: str | None = Field(None, max_length=320)
+    website: str | None = Field(None, max_length=500)
+    is_public: bool | None = None
+
+
+class NameChangeRequest(BaseModel):
+    """Request to change a group's name."""
+
+    name: str = Field(..., min_length=1, max_length=200)
+
+
+class GroupResponse(BaseModel):
+    """Full group details (Details tab / management views)."""
+
+    id: str
+    type: GroupType
+    name: str
+    slug: str
+    description: str | None = None
+    contact_email: str | None = None
+    website: str | None = None
+    avatar_url: str | None = None
+    banner_url: str | None = None
+    status: GroupStatus
+    pending_name: str | None = None
+    is_public: bool
+    created_by: str
+    created_at: datetime
+    updated_at: datetime | None = None
+    # The requesting user's role in this group, when known.
+    role: MemberRole | None = None
+    members_count: int | None = None
+
+
+class GroupListResponse(BaseModel):
+    """Paginated list of groups."""
+
+    items: list[GroupResponse]
+    total: int
+    page: int
+    page_size: int
+
+
+# --- Members ---------------------------------------------------------------
+
+
+class MemberAdd(BaseModel):
+    """Add a member directly by email (teams only)."""
+
+    email: str = Field(..., min_length=3, max_length=320)
+    role: MemberRole = "member"
+
+
+class MemberRoleUpdate(BaseModel):
+    """Change a member's role."""
+
+    role: MemberRole
+
+
+class MemberResponse(BaseModel):
+    """A group member, enriched with profile data when available."""
+
+    hanko_user_id: str
+    role: MemberRole
+    first_name: str | None = None
+    last_name: str | None = None
+    picture_url: str | None = None
+    email: str | None = None
+    created_at: datetime
+
+
+class MemberListResponse(BaseModel):
+    """Paginated list of members."""
+
+    items: list[MemberResponse]
+    total: int
+    page: int
+    page_size: int
+
+
+# --- Invitations (organizations only) --------------------------------------
+
+
+class InvitationCreate(BaseModel):
+    """Invite a user to an organization by email."""
+
+    email: str = Field(..., min_length=3, max_length=320)
+    role: MemberRole = "member"
+
+
+class InvitationResponse(BaseModel):
+    """An organization invitation."""
+
+    id: str
+    group_id: str
+    email: str
+    role: MemberRole
+    status: InvitationStatus
+    invited_by: str
+    created_at: datetime
+    expires_at: datetime
+    # Whether the invited email already has a HOT account. Set only on create;
+    # None when unknown (e.g. Hanko unreachable) or in listings.
+    recipient_exists: bool | None = None
+
+
+class MyInvitationResponse(InvitationResponse):
+    """An invitation as seen by its recipient, with group context.
+
+    Includes the accept/decline ``token``: safe to expose here because the list
+    is scoped to the recipient's own email.
+    """
+
+    token: str
+    group_name: str
+    group_type: GroupType
+
+
+# --- Consumer contract (portal, ChatMap) -----------------------------------
+
+
+class MyGroupItem(BaseModel):
+    """A group the current user belongs to (for the plan scope selector)."""
+
+    id: str
+    type: GroupType
+    slug: str
+    name: str
+    role: MemberRole
+    status: GroupStatus
+    avatar_url: str | None = None
+
+
+class MyGroupsResponse(BaseModel):
+    """The full set of groups a user belongs to (single call, no N+1)."""
+
+    groups: list[MyGroupItem]
+
+
+class MembershipCheckResponse(BaseModel):
+    """Answer to 'is this user a member of this group (with >= role)?'."""
+
+    is_member: bool
+    role: MemberRole | None = None
+    satisfies_min_role: bool
+
+
+# --- Public profiles (rendered by portal in a later stage) -----------------
+
+
+class PublicGroupResponse(BaseModel):
+    """Public-facing group profile."""
+
+    type: GroupType
+    name: str
+    slug: str
+    description: str | None = None
+    website: str | None = None
+    avatar_url: str | None = None
+    banner_url: str | None = None
+    members_count: int
+
+
+class PublicUserResponse(BaseModel):
+    """Public-facing user profile."""
+
+    slug: str
+    first_name: str | None = None
+    last_name: str | None = None
+    picture_url: str | None = None

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,9 +1,9 @@
 """SMTP helper for outbound emails."""
 
 import logging
+from email.message import EmailMessage
 
 import aiosmtplib
-from email.message import EmailMessage
 
 from app.core.config import settings
 

--- a/backend/app/services/groups_service.py
+++ b/backend/app/services/groups_service.py
@@ -59,9 +59,7 @@ def slugify(value: str) -> str:
     return value[:80]
 
 
-async def generate_unique_slug(
-    db: AsyncSession, group_type: str, name: str
-) -> str:
+async def generate_unique_slug(db: AsyncSession, group_type: str, name: str) -> str:
     """Generate a slug unique within the given group type.
 
     Falls back to a random-suffixed slug when the name yields an empty or
@@ -75,9 +73,7 @@ async def generate_unique_slug(
     suffix = 2
     while True:
         exists = await db.execute(
-            select(Group.id).where(
-                Group.type == group_type, Group.slug == candidate
-            )
+            select(Group.id).where(Group.type == group_type, Group.slug == candidate)
         )
         if exists.scalar_one_or_none() is None:
             return candidate
@@ -104,9 +100,7 @@ async def get_membership(
     return result.scalar_one_or_none()
 
 
-async def get_user_role(
-    db: AsyncSession, group_id: str, user_id: str
-) -> str | None:
+async def get_user_role(db: AsyncSession, group_id: str, user_id: str) -> str | None:
     """Return the user's role in a group, or None if not a member."""
     membership = await get_membership(db, group_id, user_id)
     return membership.role if membership else None
@@ -122,9 +116,7 @@ async def load_group_or_404(db: AsyncSession, group_id: str) -> Group:
     return group
 
 
-async def require_access(
-    db: AsyncSession, group: Group, user: HankoUser
-) -> str | None:
+async def require_access(db: AsyncSession, group: Group, user: HankoUser) -> str | None:
     """Require the user to be a member (returns role) or an account manager.
 
     Non-members who aren't account managers get 404 (don't leak existence).
@@ -134,9 +126,7 @@ async def require_access(
         return role
     if await is_account_manager(user, db):
         return None
-    raise HTTPException(
-        status_code=status.HTTP_404_NOT_FOUND, detail="Group not found"
-    )
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
 
 
 async def require_role(

--- a/backend/app/services/groups_service.py
+++ b/backend/app/services/groups_service.py
@@ -1,0 +1,294 @@
+"""Business logic for teams and organizations.
+
+Keeps slug generation, membership/role resolution and serialization out of the
+route handlers so they can be reused (and unit-tested) independently.
+"""
+
+import hashlib
+import re
+import secrets
+
+from fastapi import HTTPException, status
+from hotosm_auth.models import HankoUser
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.authz import is_account_manager
+from app.core.config import settings
+from app.db.models import Group, GroupMembership, UserProfile
+from app.schemas.groups import GroupResponse, MemberResponse, MyGroupItem
+from app.services import hanko_lookup
+
+# Slugs that would collide with app/login routes must never be minted.
+RESERVED_SLUGS = frozenset(
+    {
+        "org",
+        "team",
+        "user",
+        "users",
+        "api",
+        "admin",
+        "new",
+        "edit",
+        "me",
+        "static",
+        "assets",
+        "groups",
+        "organizations",
+        "teams",
+        "public",
+        "internal",
+        "login",
+        "profile",
+    }
+)
+
+_ROLE_RANK = {"member": 1, "manager": 2, "owner": 3}
+
+
+def role_rank(role: str | None) -> int:
+    """Return the numeric rank of a member role (owner high, None lowest)."""
+    return _ROLE_RANK.get(role or "", 0)
+
+
+def slugify(value: str) -> str:
+    """Normalize a name into a URL slug (lowercase, dash-separated)."""
+    value = value.strip().lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = re.sub(r"-+", "-", value).strip("-")
+    return value[:80]
+
+
+async def generate_unique_slug(
+    db: AsyncSession, group_type: str, name: str
+) -> str:
+    """Generate a slug unique within the given group type.
+
+    Falls back to a random-suffixed slug when the name yields an empty or
+    reserved base, and disambiguates collisions with ``-2``, ``-3``, ...
+    """
+    base = slugify(name)
+    if not base or base in RESERVED_SLUGS:
+        base = f"{group_type}-{secrets.token_hex(3)}"
+
+    candidate = base
+    suffix = 2
+    while True:
+        exists = await db.execute(
+            select(Group.id).where(
+                Group.type == group_type, Group.slug == candidate
+            )
+        )
+        if exists.scalar_one_or_none() is None:
+            return candidate
+        candidate = f"{base}-{suffix}"[:80]
+        suffix += 1
+
+
+async def get_group(db: AsyncSession, group_id: str) -> Group | None:
+    """Load a group by id."""
+    result = await db.execute(select(Group).where(Group.id == group_id))
+    return result.scalar_one_or_none()
+
+
+async def get_membership(
+    db: AsyncSession, group_id: str, user_id: str
+) -> GroupMembership | None:
+    """Load a user's membership row within a group."""
+    result = await db.execute(
+        select(GroupMembership).where(
+            GroupMembership.group_id == group_id,
+            GroupMembership.hanko_user_id == user_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_user_role(
+    db: AsyncSession, group_id: str, user_id: str
+) -> str | None:
+    """Return the user's role in a group, or None if not a member."""
+    membership = await get_membership(db, group_id, user_id)
+    return membership.role if membership else None
+
+
+async def load_group_or_404(db: AsyncSession, group_id: str) -> Group:
+    """Load a group or raise 404."""
+    group = await get_group(db, group_id)
+    if group is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Group not found"
+        )
+    return group
+
+
+async def require_access(
+    db: AsyncSession, group: Group, user: HankoUser
+) -> str | None:
+    """Require the user to be a member (returns role) or an account manager.
+
+    Non-members who aren't account managers get 404 (don't leak existence).
+    """
+    role = await get_user_role(db, group.id, user.id)
+    if role is not None:
+        return role
+    if await is_account_manager(user, db):
+        return None
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND, detail="Group not found"
+    )
+
+
+async def require_role(
+    db: AsyncSession, group: Group, user: HankoUser, min_role: str
+) -> str:
+    """Require the user to hold at least ``min_role`` within the group."""
+    role = await get_user_role(db, group.id, user.id)
+    if role is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Group not found"
+        )
+    if role_rank(role) < role_rank(min_role):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient group role",
+        )
+    return role
+
+
+async def count_members(db: AsyncSession, group_id: str) -> int:
+    """Count the members of a group."""
+    result = await db.execute(
+        select(func.count())
+        .select_from(GroupMembership)
+        .where(GroupMembership.group_id == group_id)
+    )
+    return int(result.scalar_one())
+
+
+async def list_user_groups(
+    db: AsyncSession, user_id: str, group_type: str | None = None
+) -> list[tuple[Group, str]]:
+    """Return (group, role) pairs for every group the user belongs to."""
+    stmt = (
+        select(Group, GroupMembership.role)
+        .join(GroupMembership, GroupMembership.group_id == Group.id)
+        .where(GroupMembership.hanko_user_id == user_id)
+    )
+    if group_type is not None:
+        stmt = stmt.where(Group.type == group_type)
+    stmt = stmt.order_by(Group.name)
+    result = await db.execute(stmt)
+    return [(row[0], row[1]) for row in result.all()]
+
+
+def image_url(group_id: str, kind: str, key: str | None = None) -> str:
+    """Build the URL that serves a group image.
+
+    Appends a cache-busting ``?v=`` derived from the storage key so a changed
+    image (new key on every upload) invalidates the browser cache despite the
+    stable path, while still allowing a long Cache-Control on the endpoint.
+    """
+    base = (settings.backend_url or "").rstrip("/")
+    url = f"{base}/api/groups/{group_id}/{kind}"
+    if key:
+        version = hashlib.sha256(key.encode()).hexdigest()[:8]
+        url = f"{url}?v={version}"
+    return url
+
+
+def serialize_group(
+    group: Group,
+    *,
+    role: str | None = None,
+    members_count: int | None = None,
+) -> GroupResponse:
+    """Build a GroupResponse, deriving image URLs from stored keys."""
+    return GroupResponse(
+        id=group.id,
+        type=group.type,
+        name=group.name,
+        slug=group.slug,
+        description=group.description,
+        contact_email=group.contact_email,
+        website=group.website,
+        avatar_url=(
+            image_url(group.id, "avatar", group.avatar_key)
+            if group.avatar_key
+            else None
+        ),
+        banner_url=(
+            image_url(group.id, "banner", group.banner_key)
+            if group.banner_key
+            else None
+        ),
+        status=group.status,
+        pending_name=group.pending_name,
+        is_public=group.is_public,
+        created_by=group.created_by,
+        created_at=group.created_at,
+        updated_at=group.updated_at,
+        role=role,
+        members_count=members_count,
+    )
+
+
+def to_my_group_item(group: Group, role: str) -> MyGroupItem:
+    """Build the minimal consumer-facing group item."""
+    return MyGroupItem(
+        id=group.id,
+        type=group.type,
+        slug=group.slug,
+        name=group.name,
+        role=role,
+        status=group.status,
+        avatar_url=(
+            image_url(group.id, "avatar", group.avatar_key)
+            if group.avatar_key
+            else None
+        ),
+    )
+
+
+async def list_members(
+    db: AsyncSession, group_id: str, page: int, page_size: int
+) -> tuple[list[MemberResponse], int]:
+    """List members of a group enriched with profile data (LEFT JOIN)."""
+    total_result = await db.execute(
+        select(func.count())
+        .select_from(GroupMembership)
+        .where(GroupMembership.group_id == group_id)
+    )
+    total = int(total_result.scalar_one())
+
+    stmt = (
+        select(GroupMembership, UserProfile)
+        .outerjoin(
+            UserProfile,
+            UserProfile.hanko_user_id == GroupMembership.hanko_user_id,
+        )
+        .where(GroupMembership.group_id == group_id)
+        .order_by(GroupMembership.created_at)
+        .limit(page_size)
+        .offset((page - 1) * page_size)
+    )
+    result = await db.execute(stmt)
+    rows = result.all()
+    # Resolve emails from Hanko so the UI can show them when a member has no
+    # name in their profile (better than a raw user id).
+    emails = await hanko_lookup.user_ids_to_emails(
+        [membership.hanko_user_id for membership, _ in rows]
+    )
+    items = [
+        MemberResponse(
+            hanko_user_id=membership.hanko_user_id,
+            role=membership.role,
+            first_name=profile.first_name if profile else None,
+            last_name=profile.last_name if profile else None,
+            picture_url=profile.picture_url if profile else None,
+            email=emails.get(membership.hanko_user_id),
+            created_at=membership.created_at,
+        )
+        for membership, profile in rows
+    ]
+    return items, total

--- a/backend/app/services/hanko_lookup.py
+++ b/backend/app/services/hanko_lookup.py
@@ -1,0 +1,78 @@
+"""Lookups against the Hanko database (users/emails live in Hanko, not here)."""
+
+import asyncpg
+
+from app.core.config import settings
+
+
+async def email_to_user_id(email: str) -> str | None:
+    """Resolve an email to its Hanko user id.
+
+    Returns None if the email has no account or Hanko can't be reached.
+    """
+    try:
+        conn = await asyncpg.connect(settings.hanko_db_url)
+        try:
+            return await conn.fetchval(
+                "SELECT user_id::text FROM emails "
+                "WHERE lower(address) = lower($1) LIMIT 1",
+                email,
+            )
+        finally:
+            await conn.close()
+    except Exception:
+        return None
+
+
+async def user_id_to_email(user_id: str) -> str | None:
+    """Resolve a Hanko user id to an email address, or None."""
+    try:
+        conn = await asyncpg.connect(settings.hanko_db_url)
+        try:
+            return await conn.fetchval(
+                "SELECT address FROM emails WHERE user_id = $1::uuid LIMIT 1",
+                user_id,
+            )
+        finally:
+            await conn.close()
+    except Exception:
+        return None
+
+
+async def user_ids_to_emails(user_ids: list[str]) -> dict[str, str]:
+    """Map Hanko user ids to emails in one query. Missing ids are absent."""
+    if not user_ids:
+        return {}
+    try:
+        conn = await asyncpg.connect(settings.hanko_db_url)
+        try:
+            rows = await conn.fetch(
+                "SELECT user_id::text AS uid, address FROM emails "
+                "WHERE user_id = ANY($1::uuid[])",
+                user_ids,
+            )
+            return {r["uid"]: r["address"] for r in rows}
+        finally:
+            await conn.close()
+    except Exception:
+        return {}
+
+
+async def email_has_account(email: str) -> bool | None:
+    """Whether an email is registered in Hanko.
+
+    Returns None when it can't be determined (Hanko unreachable) so callers can
+    degrade gracefully instead of blocking.
+    """
+    try:
+        conn = await asyncpg.connect(settings.hanko_db_url)
+        try:
+            row = await conn.fetchval(
+                "SELECT 1 FROM emails WHERE lower(address) = lower($1) LIMIT 1",
+                email,
+            )
+            return row is not None
+        finally:
+            await conn.close()
+    except Exception:
+        return None

--- a/backend/app/services/s3_service.py
+++ b/backend/app/services/s3_service.py
@@ -1,0 +1,120 @@
+"""S3/MinIO storage for group avatar/banner images (synchronous boto3).
+
+Mirrors portal's ``s3_service`` with a local-filesystem fallback so dev works
+without object storage. Image keys are namespaced by group and kind
+(``avatar`` | ``banner``).
+"""
+
+import uuid
+from pathlib import Path
+
+import boto3
+
+from app.core.config import settings
+
+_LOCAL_UPLOADS_DIR = Path("/app/uploads")
+_CONTENT_TYPE_BY_EXT = {
+    ".webp": "image/webp",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+}
+
+
+def is_s3_configured() -> bool:
+    """Return True when object storage is configured."""
+    return bool(settings.s3_endpoint_url and settings.s3_bucket_name)
+
+
+def is_local_key(key: str) -> bool:
+    """Return True when the key points at the local-filesystem fallback."""
+    return key.startswith("local/")
+
+
+def _local_path(key: str) -> Path:
+    return _LOCAL_UPLOADS_DIR / key[len("local/") :]
+
+
+def _get_s3_client():
+    kwargs: dict = {"endpoint_url": settings.s3_endpoint_url}
+    if settings.s3_access_key:
+        kwargs["aws_access_key_id"] = settings.s3_access_key
+    if settings.s3_secret_key:
+        kwargs["aws_secret_access_key"] = settings.s3_secret_key
+    return boto3.client("s3", **kwargs)
+
+
+def upload_group_image_local(
+    data: bytes, group_id: str, kind: str, ext: str
+) -> str:
+    """Store image bytes on the local filesystem. Returns storage key."""
+    key = f"local/groups/{group_id}/{kind}/{uuid.uuid4()}{ext}"
+    path = _local_path(key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return key
+
+
+def get_group_image_local(key: str) -> tuple[bytes, str]:
+    """Fetch image bytes and content-type from the local filesystem."""
+    path = _local_path(key)
+    ext = path.suffix.lower()
+    return path.read_bytes(), _CONTENT_TYPE_BY_EXT.get(
+        ext, "application/octet-stream"
+    )
+
+
+def delete_group_image_local(key: str) -> None:
+    """Delete a locally-stored image (no-op if missing)."""
+    _local_path(key).unlink(missing_ok=True)
+
+
+def upload_group_image(
+    data: bytes, content_type: str, group_id: str, kind: str, ext: str
+) -> str:
+    """Upload image bytes to S3. Returns the storage key."""
+    key = f"groups/{group_id}/{kind}/{uuid.uuid4()}{ext}"
+    _get_s3_client().put_object(
+        Bucket=settings.s3_bucket_name,
+        Key=key,
+        Body=data,
+        ContentType=content_type,
+    )
+    return key
+
+
+def get_group_image(key: str) -> tuple[bytes, str]:
+    """Fetch image bytes and content-type from S3."""
+    response = _get_s3_client().get_object(
+        Bucket=settings.s3_bucket_name, Key=key
+    )
+    data = response["Body"].read()
+    content_type = response.get("ContentType", "application/octet-stream")
+    return data, content_type
+
+
+def delete_group_image(key: str) -> None:
+    """Delete an image from S3."""
+    _get_s3_client().delete_object(Bucket=settings.s3_bucket_name, Key=key)
+
+
+def store_image(data: bytes, group_id: str, kind: str, ext: str, content_type: str) -> str:
+    """Store an image via S3 or the local fallback, returning the key."""
+    if is_s3_configured():
+        return upload_group_image(data, content_type, group_id, kind, ext)
+    return upload_group_image_local(data, group_id, kind, ext)
+
+
+def load_image(key: str) -> tuple[bytes, str]:
+    """Load an image by key from wherever it is stored."""
+    if is_local_key(key):
+        return get_group_image_local(key)
+    return get_group_image(key)
+
+
+def remove_image(key: str) -> None:
+    """Remove an image by key from wherever it is stored."""
+    if is_local_key(key):
+        delete_group_image_local(key)
+    else:
+        delete_group_image(key)

--- a/backend/app/services/s3_service.py
+++ b/backend/app/services/s3_service.py
@@ -44,9 +44,7 @@ def _get_s3_client():
     return boto3.client("s3", **kwargs)
 
 
-def upload_group_image_local(
-    data: bytes, group_id: str, kind: str, ext: str
-) -> str:
+def upload_group_image_local(data: bytes, group_id: str, kind: str, ext: str) -> str:
     """Store image bytes on the local filesystem. Returns storage key."""
     key = f"local/groups/{group_id}/{kind}/{uuid.uuid4()}{ext}"
     path = _local_path(key)
@@ -59,9 +57,7 @@ def get_group_image_local(key: str) -> tuple[bytes, str]:
     """Fetch image bytes and content-type from the local filesystem."""
     path = _local_path(key)
     ext = path.suffix.lower()
-    return path.read_bytes(), _CONTENT_TYPE_BY_EXT.get(
-        ext, "application/octet-stream"
-    )
+    return path.read_bytes(), _CONTENT_TYPE_BY_EXT.get(ext, "application/octet-stream")
 
 
 def delete_group_image_local(key: str) -> None:
@@ -85,9 +81,7 @@ def upload_group_image(
 
 def get_group_image(key: str) -> tuple[bytes, str]:
     """Fetch image bytes and content-type from S3."""
-    response = _get_s3_client().get_object(
-        Bucket=settings.s3_bucket_name, Key=key
-    )
+    response = _get_s3_client().get_object(Bucket=settings.s3_bucket_name, Key=key)
     data = response["Body"].read()
     content_type = response.get("ContentType", "application/octet-stream")
     return data, content_type
@@ -98,7 +92,9 @@ def delete_group_image(key: str) -> None:
     _get_s3_client().delete_object(Bucket=settings.s3_bucket_name, Key=key)
 
 
-def store_image(data: bytes, group_id: str, kind: str, ext: str, content_type: str) -> str:
+def store_image(
+    data: bytes, group_id: str, kind: str, ext: str, content_type: str
+) -> str:
     """Store an image via S3 or the local fallback, returning the key."""
     if is_s3_configured():
         return upload_group_image(data, content_type, group_id, kind, ext)

--- a/backend/app/tests/__init__.py
+++ b/backend/app/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Backend test suite."""

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -75,15 +75,9 @@ def mock_hanko_lookup():
         return {uid: known_ids[uid] for uid in user_ids if uid in known_ids}
 
     with (
-        patch(
-            "app.services.hanko_lookup.email_to_user_id", new=_email_to_user_id
-        ),
-        patch(
-            "app.services.hanko_lookup.email_has_account", new=_email_has_account
-        ),
-        patch(
-            "app.services.hanko_lookup.user_id_to_email", new=_user_id_to_email
-        ),
+        patch("app.services.hanko_lookup.email_to_user_id", new=_email_to_user_id),
+        patch("app.services.hanko_lookup.email_has_account", new=_email_has_account),
+        patch("app.services.hanko_lookup.user_id_to_email", new=_user_id_to_email),
         patch(
             "app.services.hanko_lookup.user_ids_to_emails",
             new=_user_ids_to_emails,

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -1,0 +1,147 @@
+"""Pytest fixtures for the login backend.
+
+Uses an in-memory SQLite database and overrides the Hanko auth dependency so
+tests never validate a real JWT. The account-manager role is resolved against
+the real ``account_managers`` table (not overridden) so its logic is exercised.
+"""
+
+import os
+
+# Settings() is instantiated at import time and requires these; set them before
+# importing anything under ``app``.
+os.environ.setdefault("COOKIE_SECRET", "x" * 40)
+os.environ.setdefault("ADMIN_EMAILS", "admin@test.org")
+
+from collections.abc import AsyncGenerator  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
+from unittest.mock import patch  # noqa: E402
+
+import pytest  # noqa: E402
+from hotosm_auth.models import HankoUser  # noqa: E402
+from hotosm_auth_fastapi import get_current_user  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+from sqlalchemy.ext.asyncio import (  # noqa: E402
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.db.database import Base, get_db  # noqa: E402
+from app.main import app  # noqa: E402
+
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+
+def make_user(user_id: str, email: str | None = None) -> HankoUser:
+    """Build a HankoUser for tests."""
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return HankoUser(
+        id=user_id,
+        email=email,
+        email_verified=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+# Convenience test identities.
+USER_A = make_user("user-a-id", "a@test.org")
+USER_B = make_user("user-b-id", "b@test.org")
+ADMIN = make_user("admin-id", "admin@test.org")
+
+
+_KNOWN_EMAILS = {
+    USER_A.email: USER_A.id,
+    USER_B.email: USER_B.id,
+    ADMIN.email: ADMIN.id,
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_hanko_lookup():
+    """Stub the Hanko email lookups (no Hanko DB in tests)."""
+    known_ids = {v: k for k, v in _KNOWN_EMAILS.items()}
+
+    async def _email_to_user_id(email: str) -> str | None:
+        return _KNOWN_EMAILS.get(email.strip().lower())
+
+    async def _email_has_account(email: str) -> bool:
+        return email.strip().lower() in _KNOWN_EMAILS
+
+    async def _user_id_to_email(user_id: str) -> str | None:
+        return known_ids.get(user_id)
+
+    async def _user_ids_to_emails(user_ids: list[str]) -> dict[str, str]:
+        return {uid: known_ids[uid] for uid in user_ids if uid in known_ids}
+
+    with (
+        patch(
+            "app.services.hanko_lookup.email_to_user_id", new=_email_to_user_id
+        ),
+        patch(
+            "app.services.hanko_lookup.email_has_account", new=_email_has_account
+        ),
+        patch(
+            "app.services.hanko_lookup.user_id_to_email", new=_user_id_to_email
+        ),
+        patch(
+            "app.services.hanko_lookup.user_ids_to_emails",
+            new=_user_ids_to_emails,
+        ),
+    ):
+        yield
+
+
+@pytest.fixture(scope="session")
+def anyio_backend():
+    """Use asyncio backend for pytest-asyncio."""
+    return "asyncio"
+
+
+@pytest.fixture
+async def test_engine():
+    """Create an in-memory SQLite engine with all tables."""
+    engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+async def db(test_engine) -> AsyncGenerator[AsyncSession, None]:
+    """Provide a test database session."""
+    session_maker = async_sessionmaker(
+        test_engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with session_maker() as session:
+        yield session
+
+
+@pytest.fixture
+def auth() -> dict[str, HankoUser]:
+    """Mutable holder for the current test user (default USER_A)."""
+    return {"user": USER_A}
+
+
+@pytest.fixture
+async def client(
+    db: AsyncSession, auth: dict[str, HankoUser]
+) -> AsyncGenerator[AsyncClient, None]:
+    """AsyncClient with DB and auth dependency overrides.
+
+    Change the acting user with ``auth["user"] = ...`` inside a test.
+    """
+
+    async def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = lambda: auth["user"]
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as test_client:
+        yield test_client
+
+    app.dependency_overrides.clear()

--- a/backend/app/tests/test_groups.py
+++ b/backend/app/tests/test_groups.py
@@ -1,0 +1,203 @@
+"""Integration tests for group CRUD, members and access control."""
+
+from app.tests.conftest import ADMIN, USER_A, USER_B
+
+
+async def _create_team(client, name="Mappers", member_emails=None):
+    resp = await client.post(
+        "/api/groups",
+        json={
+            "type": "team",
+            "name": name,
+            "member_emails": member_emails or [],
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def test_create_team_is_approved_with_owner(client):
+    body = await _create_team(client)
+    assert body["type"] == "team"
+    assert body["status"] == "approved"
+    assert body["role"] == "owner"
+    assert body["members_count"] == 1
+    assert body["slug"] == "mappers"
+
+
+async def test_create_team_with_member_emails(client, auth):
+    team = await _create_team(client, member_emails=[USER_B.email])
+    assert team["members_count"] == 2
+    auth["user"] = USER_B
+    mine = await client.get("/api/groups")
+    assert any(g["id"] == team["id"] for g in mine.json()["groups"])
+
+
+async def test_create_org_is_pending(client):
+    resp = await client.post(
+        "/api/groups", json={"type": "organization", "name": "ADF Haiti"}
+    )
+    assert resp.status_code == 201
+    assert resp.json()["status"] == "pending"
+
+
+async def test_list_my_groups_only_mine(client, auth):
+    await _create_team(client, name="Team A")
+    auth["user"] = USER_B
+    await _create_team(client, name="Team B")
+
+    resp = await client.get("/api/groups")
+    names = {g["name"] for g in resp.json()["groups"]}
+    assert names == {"Team B"}
+
+
+async def test_list_my_groups_type_filter(client):
+    await _create_team(client, name="My Team")
+    await client.post(
+        "/api/groups", json={"type": "organization", "name": "My Org"}
+    )
+    resp = await client.get("/api/groups", params={"type": "organization"})
+    groups = resp.json()["groups"]
+    assert len(groups) == 1
+    assert groups[0]["type"] == "organization"
+
+
+async def test_non_member_gets_404(client, auth):
+    team = await _create_team(client)
+    auth["user"] = USER_B
+    resp = await client.get(f"/api/groups/{team['id']}")
+    assert resp.status_code == 404
+
+
+async def test_account_manager_can_view_any_group(client, auth):
+    team = await _create_team(client)
+    auth["user"] = ADMIN  # admin@test.org is an account manager by allowlist
+    resp = await client.get(f"/api/groups/{team['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["role"] is None  # AM is not a member
+
+
+async def test_team_add_member_directly(client, auth):
+    team = await _create_team(client)
+    resp = await client.post(
+        f"/api/groups/{team['id']}/members",
+        json={"email": USER_B.email, "role": "member"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["total"] == 2
+
+    auth["user"] = USER_B
+    mine = await client.get("/api/groups")
+    assert len(mine.json()["groups"]) == 1
+
+
+async def test_team_add_member_unknown_email_404(client):
+    team = await _create_team(client)
+    resp = await client.post(
+        f"/api/groups/{team['id']}/members",
+        json={"email": "nobody@test.org", "role": "member"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_org_rejects_direct_member_add(client):
+    resp = await client.post(
+        "/api/groups", json={"type": "organization", "name": "Org"}
+    )
+    org_id = resp.json()["id"]
+    resp = await client.post(
+        f"/api/groups/{org_id}/members",
+        json={"email": USER_B.email, "role": "member"},
+    )
+    assert resp.status_code == 400
+
+
+async def test_member_cannot_update_details(client, auth):
+    team = await _create_team(client)
+    await client.post(
+        f"/api/groups/{team['id']}/members",
+        json={"email": USER_B.email, "role": "member"},
+    )
+    auth["user"] = USER_B
+    resp = await client.patch(
+        f"/api/groups/{team['id']}", json={"description": "hi"}
+    )
+    assert resp.status_code == 403
+
+
+async def test_owner_updates_details(client):
+    team = await _create_team(client)
+    resp = await client.patch(
+        f"/api/groups/{team['id']}",
+        json={"description": "We map things", "is_public": True},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["description"] == "We map things"
+    assert resp.json()["is_public"] is True
+
+
+async def test_team_name_change_is_direct(client):
+    team = await _create_team(client)
+    resp = await client.post(
+        f"/api/groups/{team['id']}/name-change", json={"name": "New Name"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "New Name"
+    assert resp.json()["pending_name"] is None
+
+
+async def test_transfer_ownership(client, auth):
+    team = await _create_team(client)
+    await client.post(
+        f"/api/groups/{team['id']}/members",
+        json={"email": USER_B.email, "role": "member"},
+    )
+    resp = await client.patch(
+        f"/api/groups/{team['id']}/members/{USER_B.id}",
+        json={"role": "owner"},
+    )
+    assert resp.status_code == 204
+
+    # The former owner is now a manager; USER_B is the owner.
+    resp = await client.get(f"/api/groups/{team['id']}")
+    assert resp.json()["role"] == "manager"
+
+
+async def test_delete_group_owner_only(client, auth):
+    team = await _create_team(client)
+    await client.post(
+        f"/api/groups/{team['id']}/members",
+        json={"email": USER_B.email, "role": "member"},
+    )
+    auth["user"] = USER_B
+    resp = await client.delete(f"/api/groups/{team['id']}")
+    assert resp.status_code == 403
+
+    auth["user"] = USER_A
+    resp = await client.delete(f"/api/groups/{team['id']}")
+    assert resp.status_code == 204
+    resp = await client.get(f"/api/groups/{team['id']}")
+    assert resp.status_code == 404
+
+
+async def test_membership_check(client):
+    team = await _create_team(client)
+    await client.post(
+        f"/api/groups/{team['id']}/members",
+        json={"email": USER_B.email, "role": "manager"},
+    )
+    resp = await client.get(
+        f"/api/groups/{team['id']}/membership/{USER_B.id}",
+        params={"min_role": "manager"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["is_member"] is True
+    assert body["role"] == "manager"
+    assert body["satisfies_min_role"] is True
+
+    resp = await client.get(
+        f"/api/groups/{team['id']}/membership/{USER_B.id}",
+        params={"min_role": "owner"},
+    )
+    assert resp.json()["satisfies_min_role"] is False

--- a/backend/app/tests/test_groups.py
+++ b/backend/app/tests/test_groups.py
@@ -53,9 +53,7 @@ async def test_list_my_groups_only_mine(client, auth):
 
 async def test_list_my_groups_type_filter(client):
     await _create_team(client, name="My Team")
-    await client.post(
-        "/api/groups", json={"type": "organization", "name": "My Org"}
-    )
+    await client.post("/api/groups", json={"type": "organization", "name": "My Org"})
     resp = await client.get("/api/groups", params={"type": "organization"})
     groups = resp.json()["groups"]
     assert len(groups) == 1
@@ -119,9 +117,7 @@ async def test_member_cannot_update_details(client, auth):
         json={"email": USER_B.email, "role": "member"},
     )
     auth["user"] = USER_B
-    resp = await client.patch(
-        f"/api/groups/{team['id']}", json={"description": "hi"}
-    )
+    resp = await client.patch(f"/api/groups/{team['id']}", json={"description": "hi"})
     assert resp.status_code == 403
 
 

--- a/backend/app/tests/test_invitations.py
+++ b/backend/app/tests/test_invitations.py
@@ -10,9 +10,7 @@ from app.tests.conftest import USER_B, make_user
 
 
 async def _create_org(client, db, name="ADF Haiti"):
-    resp = await client.post(
-        "/api/groups", json={"type": "organization", "name": name}
-    )
+    resp = await client.post("/api/groups", json={"type": "organization", "name": name})
     org = resp.json()
     # Approve so invitations are allowed (pending orgs can't invite).
     group = await db.get(Group, org["id"])
@@ -22,9 +20,7 @@ async def _create_org(client, db, name="ADF Haiti"):
 
 
 async def _invite(client, org_id, email="invitee@test.org"):
-    with patch(
-        "app.api.routes.invitations.send_email", new=AsyncMock()
-    ) as mock:
+    with patch("app.api.routes.invitations.send_email", new=AsyncMock()) as mock:
         resp = await client.post(
             f"/api/groups/{org_id}/invitations", json={"email": email}
         )
@@ -40,9 +36,7 @@ async def test_invite_sends_email_and_creates_pending(client, db):
 
 
 async def test_teams_cannot_invite(client):
-    resp = await client.post(
-        "/api/groups", json={"type": "team", "name": "T"}
-    )
+    resp = await client.post("/api/groups", json={"type": "team", "name": "T"})
     team_id = resp.json()["id"]
     resp = await client.post(
         f"/api/groups/{team_id}/invitations", json={"email": "x@test.org"}
@@ -109,16 +103,12 @@ async def test_accept_expired_invitation(client, auth, db):
     invitee = make_user("invitee-id", "invitee@test.org")
     await _invite(client, org["id"], email=invitee.email)
 
-    invitation = (
-        await db.execute(select(GroupInvitation))
-    ).scalar_one()
+    invitation = (await db.execute(select(GroupInvitation))).scalar_one()
     invitation.expires_at = datetime.now(timezone.utc) - timedelta(days=1)
     await db.commit()
 
     auth["user"] = invitee
-    resp = await client.post(
-        f"/api/me/invitations/{invitation.token}/accept"
-    )
+    resp = await client.post(f"/api/me/invitations/{invitation.token}/accept")
     assert resp.status_code == 410
 
 
@@ -127,9 +117,7 @@ async def test_revoke_invitation(client, auth, db):
     resp, _ = await _invite(client, org["id"])
     invitation_id = resp.json()["id"]
 
-    resp = await client.delete(
-        f"/api/groups/{org['id']}/invitations/{invitation_id}"
-    )
+    resp = await client.delete(f"/api/groups/{org['id']}/invitations/{invitation_id}")
     assert resp.status_code == 204
 
     invitation = (await db.execute(select(GroupInvitation))).scalar_one()

--- a/backend/app/tests/test_invitations.py
+++ b/backend/app/tests/test_invitations.py
@@ -1,0 +1,136 @@
+"""Tests for the organization invitation lifecycle."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy import select
+
+from app.db.models import Group, GroupInvitation
+from app.tests.conftest import USER_B, make_user
+
+
+async def _create_org(client, db, name="ADF Haiti"):
+    resp = await client.post(
+        "/api/groups", json={"type": "organization", "name": name}
+    )
+    org = resp.json()
+    # Approve so invitations are allowed (pending orgs can't invite).
+    group = await db.get(Group, org["id"])
+    group.status = "approved"
+    await db.commit()
+    return org
+
+
+async def _invite(client, org_id, email="invitee@test.org"):
+    with patch(
+        "app.api.routes.invitations.send_email", new=AsyncMock()
+    ) as mock:
+        resp = await client.post(
+            f"/api/groups/{org_id}/invitations", json={"email": email}
+        )
+    return resp, mock
+
+
+async def test_invite_sends_email_and_creates_pending(client, db):
+    org = await _create_org(client, db)
+    resp, mock = await _invite(client, org["id"])
+    assert resp.status_code == 201
+    assert resp.json()["status"] == "pending"
+    assert resp.json()["email"] == "invitee@test.org"
+
+
+async def test_teams_cannot_invite(client):
+    resp = await client.post(
+        "/api/groups", json={"type": "team", "name": "T"}
+    )
+    team_id = resp.json()["id"]
+    resp = await client.post(
+        f"/api/groups/{team_id}/invitations", json={"email": "x@test.org"}
+    )
+    assert resp.status_code == 400
+
+
+async def test_cannot_invite_to_pending_org(client):
+    resp = await client.post(
+        "/api/groups", json={"type": "organization", "name": "Pending Org"}
+    )
+    org_id = resp.json()["id"]
+    resp = await client.post(
+        f"/api/groups/{org_id}/invitations", json={"email": "x@test.org"}
+    )
+    assert resp.status_code == 400
+
+
+async def test_duplicate_pending_invite_conflicts(client, db):
+    org = await _create_org(client, db)
+    await _invite(client, org["id"])
+    resp, _ = await _invite(client, org["id"])
+    assert resp.status_code == 409
+
+
+async def test_full_invite_accept_flow(client, auth, db):
+    org = await _create_org(client, db)
+    invitee = make_user("invitee-id", "invitee@test.org")
+    await _invite(client, org["id"], email=invitee.email)
+
+    # The recipient sees the invitation in their inbox with group context,
+    # including the token they use to accept it in-app.
+    auth["user"] = invitee
+    inbox = await client.get("/api/me/invitations")
+    assert len(inbox.json()) == 1
+    assert inbox.json()[0]["group_name"] == "ADF Haiti"
+    token = inbox.json()[0]["token"]
+    assert token
+
+    resp = await client.post(f"/api/me/invitations/{token}/accept")
+    assert resp.status_code == 204
+
+    # The invitee is now a member of the org.
+    mine = await client.get("/api/groups")
+    assert any(g["id"] == org["id"] for g in mine.json()["groups"])
+
+    # Inbox is now empty (invitation accepted).
+    inbox = await client.get("/api/me/invitations")
+    assert inbox.json() == []
+
+
+async def test_accept_wrong_email_forbidden(client, auth, db):
+    org = await _create_org(client, db)
+    await _invite(client, org["id"], email="someone@test.org")
+    token = (await db.execute(select(GroupInvitation.token))).scalar_one()
+
+    auth["user"] = USER_B  # b@test.org != someone@test.org
+    resp = await client.post(f"/api/me/invitations/{token}/accept")
+    assert resp.status_code == 403
+
+
+async def test_accept_expired_invitation(client, auth, db):
+    org = await _create_org(client, db)
+    invitee = make_user("invitee-id", "invitee@test.org")
+    await _invite(client, org["id"], email=invitee.email)
+
+    invitation = (
+        await db.execute(select(GroupInvitation))
+    ).scalar_one()
+    invitation.expires_at = datetime.now(timezone.utc) - timedelta(days=1)
+    await db.commit()
+
+    auth["user"] = invitee
+    resp = await client.post(
+        f"/api/me/invitations/{invitation.token}/accept"
+    )
+    assert resp.status_code == 410
+
+
+async def test_revoke_invitation(client, auth, db):
+    org = await _create_org(client, db)
+    resp, _ = await _invite(client, org["id"])
+    invitation_id = resp.json()["id"]
+
+    resp = await client.delete(
+        f"/api/groups/{org['id']}/invitations/{invitation_id}"
+    )
+    assert resp.status_code == 204
+
+    invitation = (await db.execute(select(GroupInvitation))).scalar_one()
+    assert invitation.status == "revoked"

--- a/backend/app/tests/test_org_approval.py
+++ b/backend/app/tests/test_org_approval.py
@@ -7,9 +7,7 @@ from app.tests.conftest import ADMIN, USER_A, USER_B, make_user
 
 
 async def _create_org(client, name="ADF Haiti"):
-    resp = await client.post(
-        "/api/groups", json={"type": "organization", "name": name}
-    )
+    resp = await client.post("/api/groups", json={"type": "organization", "name": name})
     assert resp.status_code == 201
     return resp.json()
 
@@ -30,9 +28,7 @@ async def test_approve_notifies_owner(client, auth):
     with patch(
         "app.api.routes.organizations_admin.send_email", new=AsyncMock()
     ) as mock:
-        resp = await client.post(
-            f"/api/admin/organizations/{org['id']}/approve"
-        )
+        resp = await client.post(f"/api/admin/organizations/{org['id']}/approve")
     assert resp.status_code == 204
     mock.assert_awaited_once()
     assert mock.await_args.kwargs["to"] == [USER_A.email]
@@ -87,9 +83,7 @@ async def test_name_change_requires_approval_when_approved(client, auth):
 
     # Account manager approves the name change.
     auth["user"] = ADMIN
-    resp = await client.post(
-        f"/api/admin/organizations/{org['id']}/approve-name"
-    )
+    resp = await client.post(f"/api/admin/organizations/{org['id']}/approve-name")
     assert resp.status_code == 204
 
     resp = await client.get(f"/api/groups/{org['id']}")

--- a/backend/app/tests/test_org_approval.py
+++ b/backend/app/tests/test_org_approval.py
@@ -1,0 +1,159 @@
+"""Tests for organization approval, name moderation and the AM role."""
+
+from unittest.mock import AsyncMock, patch
+
+from app.db.models import AccountManager
+from app.tests.conftest import ADMIN, USER_A, USER_B, make_user
+
+
+async def _create_org(client, name="ADF Haiti"):
+    resp = await client.post(
+        "/api/groups", json={"type": "organization", "name": name}
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+async def test_approve_organization(client, auth):
+    org = await _create_org(client)
+    auth["user"] = ADMIN
+    resp = await client.post(f"/api/admin/organizations/{org['id']}/approve")
+    assert resp.status_code == 204
+
+    resp = await client.get(f"/api/groups/{org['id']}")
+    assert resp.json()["status"] == "approved"
+
+
+async def test_approve_notifies_owner(client, auth):
+    org = await _create_org(client)  # owner = USER_A (default acting user)
+    auth["user"] = ADMIN
+    with patch(
+        "app.api.routes.organizations_admin.send_email", new=AsyncMock()
+    ) as mock:
+        resp = await client.post(
+            f"/api/admin/organizations/{org['id']}/approve"
+        )
+    assert resp.status_code == 204
+    mock.assert_awaited_once()
+    assert mock.await_args.kwargs["to"] == [USER_A.email]
+
+
+async def test_reject_notifies_owner_with_reason(client, auth):
+    org = await _create_org(client)
+    auth["user"] = ADMIN
+    with patch(
+        "app.api.routes.organizations_admin.send_email", new=AsyncMock()
+    ) as mock:
+        resp = await client.post(
+            f"/api/admin/organizations/{org['id']}/reject",
+            json={"reason": "duplicate"},
+        )
+    assert resp.status_code == 204
+    mock.assert_awaited_once()
+    assert "duplicate" in mock.await_args.kwargs["text_body"]
+
+
+async def test_non_am_cannot_approve(client, auth):
+    org = await _create_org(client)
+    auth["user"] = USER_B  # not admin, not account manager
+    resp = await client.post(f"/api/admin/organizations/{org['id']}/approve")
+    assert resp.status_code == 403
+
+
+async def test_reject_organization(client, auth):
+    org = await _create_org(client)
+    auth["user"] = ADMIN
+    resp = await client.post(
+        f"/api/admin/organizations/{org['id']}/reject",
+        json={"reason": "duplicate"},
+    )
+    assert resp.status_code == 204
+
+
+async def test_name_change_requires_approval_when_approved(client, auth):
+    org = await _create_org(client)
+    auth["user"] = ADMIN
+    await client.post(f"/api/admin/organizations/{org['id']}/approve")
+
+    # Owner requests a name change: it is staged, not applied.
+    auth["user"] = USER_A
+    resp = await client.post(
+        f"/api/groups/{org['id']}/name-change", json={"name": "ADF New"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "ADF Haiti"
+    assert body["pending_name"] == "ADF New"
+
+    # Account manager approves the name change.
+    auth["user"] = ADMIN
+    resp = await client.post(
+        f"/api/admin/organizations/{org['id']}/approve-name"
+    )
+    assert resp.status_code == 204
+
+    resp = await client.get(f"/api/groups/{org['id']}")
+    body = resp.json()
+    assert body["name"] == "ADF New"
+    assert body["pending_name"] is None
+    assert body["slug"] == "adf-new"
+
+
+async def test_owner_can_edit_details_but_not_name(client, auth):
+    org = await _create_org(client)
+    auth["user"] = ADMIN
+    await client.post(f"/api/admin/organizations/{org['id']}/approve")
+    auth["user"] = USER_A
+    # PATCH ignores name entirely (not an accepted field).
+    resp = await client.patch(
+        f"/api/groups/{org['id']}",
+        json={"website": "https://adf.ht", "name": "Hacked"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "ADF Haiti"
+    assert resp.json()["website"] == "https://adf.ht"
+
+
+async def test_am_role_via_allowlist_and_table(client, auth, db):
+    # admin@test.org resolves as AM through the email allowlist.
+    auth["user"] = ADMIN
+    resp = await client.get("/api/me/roles")
+    assert resp.json() == {"is_admin": True, "is_account_manager": True}
+
+    # A plain user is neither.
+    auth["user"] = USER_B
+    resp = await client.get("/api/me/roles")
+    assert resp.json() == {"is_admin": False, "is_account_manager": False}
+
+    # Granting an account_managers row makes them an AM (but not admin).
+    db.add(AccountManager(hanko_user_id=USER_B.id, granted_by=ADMIN.id))
+    await db.commit()
+    resp = await client.get("/api/me/roles")
+    assert resp.json() == {"is_admin": False, "is_account_manager": True}
+
+
+async def test_admin_grants_and_revokes_am(client, auth):
+    target = make_user("target-id", "target@test.org")
+    auth["user"] = ADMIN
+    resp = await client.put(f"/api/admin/account-managers/{target.id}")
+    assert resp.status_code == 204
+
+    resp = await client.get("/api/admin/account-managers")
+    assert any(am["hanko_user_id"] == target.id for am in resp.json())
+
+    # The granted user can now act as an AM.
+    auth["user"] = target
+    org = await _create_org(client, name="Test Org")
+    auth["user"] = ADMIN
+    resp = await client.post(f"/api/admin/organizations/{org['id']}/approve")
+    assert resp.status_code == 204
+
+    resp = await client.delete(f"/api/admin/account-managers/{target.id}")
+    assert resp.status_code == 204
+
+
+async def test_non_admin_cannot_grant_am(client, auth):
+    # An account manager is not an admin, so cannot grant the role.
+    resp = await client.put(f"/api/admin/account-managers/{USER_B.id}")
+    # USER_A (default) is neither admin nor AM.
+    assert resp.status_code == 403

--- a/backend/app/tests/test_slug.py
+++ b/backend/app/tests/test_slug.py
@@ -1,0 +1,47 @@
+"""Unit tests for slug generation."""
+
+import pytest
+
+from app.db.models import Group
+from app.services import groups_service
+
+
+def test_slugify_basic():
+    assert groups_service.slugify("ADF Haiti") == "adf-haiti"
+    assert groups_service.slugify("  Hello  World  ") == "hello-world"
+    assert groups_service.slugify("Foo!!!Bar??") == "foo-bar"
+    assert groups_service.slugify("café münchen") == "caf-m-nchen"
+
+
+async def test_unique_slug_no_collision(db):
+    slug = await groups_service.generate_unique_slug(db, "team", "Mappers")
+    assert slug == "mappers"
+
+
+async def test_unique_slug_collision_suffixes(db):
+    db.add(Group(type="team", name="Mappers", slug="mappers", created_by="u"))
+    await db.commit()
+    slug = await groups_service.generate_unique_slug(db, "team", "Mappers")
+    assert slug == "mappers-2"
+
+
+async def test_same_slug_allowed_across_types(db):
+    db.add(Group(type="team", name="Acme", slug="acme", created_by="u"))
+    await db.commit()
+    # An organization may reuse a slug held by a team (separate namespace).
+    slug = await groups_service.generate_unique_slug(db, "organization", "Acme")
+    assert slug == "acme"
+
+
+async def test_reserved_slug_gets_fallback(db):
+    slug = await groups_service.generate_unique_slug(db, "team", "admin")
+    assert slug != "admin"
+    assert slug.startswith("team-")
+
+
+@pytest.mark.parametrize(
+    ("role", "rank"),
+    [("owner", 3), ("manager", 2), ("member", 1), (None, 0), ("bogus", 0)],
+)
+def test_role_rank(role, rank):
+    assert groups_service.role_rank(role) == rank

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "psycopg2-binary>=2.9.0",
     "psycopg[binary]>=3.2.0",
     "aiosmtplib>=3.0.0",
+    "boto3>=1.34.0",
+    "pillow>=11.0.0",
     "hotosm-auth[fastapi]==0.2.12",
 ]
 
@@ -24,6 +26,7 @@ dev = [
     "pytest>=8.3.5",
     "pytest-asyncio>=0.24.0",
     "httpx>=0.28.1",
+    "aiosqlite>=0.20.0",
     "ruff>=0.9.0",
 ]
 
@@ -65,6 +68,8 @@ max-returns = 6
 max-statements = 50
 [tool.ruff.lint.isort]
 known-first-party = ["app"]
+[tool.ruff.lint.per-file-ignores]
+"app/tests/*" = ["D1", "S101", "S105", "S106", "PLR2004"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -12,6 +12,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.17.2"
 source = { registry = "https://pypi.org/simple" }
@@ -95,6 +104,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
     { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
     { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/93/5f98e422ced57a359e3b7827ab79b359d67456abb9c5840b0c5eb7b90e6b/boto3-1.43.52.tar.gz", hash = "sha256:3da09a393c050906d407023bee5fb5b5fb333378513af1a1a51159db870b572f", size = 112680, upload-time = "2026-07-20T19:31:28.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/57/31e6f45c3e236273f9f83f047ae579a90c4be8c6dc1b8366d63a6dcd9841/boto3-1.43.52-py3-none-any.whl", hash = "sha256:1af1950c2b2400267c93d971d588367fc73554e02b4f435a50a5e930a7c93526", size = 140026, upload-time = "2026-07-20T19:31:26.247Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/18/f6f02b1acea9a7c42571813ad4c3e19460206e67ca99af402b7ae3d7584d/botocore-1.43.52.tar.gz", hash = "sha256:3c25e11796ae6e295f1cc3a7760e808c26c432cd580d6a608f32da24715c389b", size = 15717429, upload-time = "2026-07-20T19:31:17.296Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/e8/99f83445500c565e1850b20d510821d1eb635283171573340aa310d478b5/botocore-1.43.52-py3-none-any.whl", hash = "sha256:43715e971b306f86d5918b3b728ec62aae3f4be49e1606058ef1f0b87dcbad9e", size = 15402564, upload-time = "2026-07-20T19:31:13.936Z" },
 ]
 
 [[package]]
@@ -327,9 +364,11 @@ dependencies = [
     { name = "aiosmtplib" },
     { name = "alembic" },
     { name = "asyncpg" },
+    { name = "boto3" },
     { name = "fastapi" },
     { name = "hotosm-auth", extra = ["fastapi"] },
     { name = "httpx" },
+    { name = "pillow" },
     { name = "psycopg", extra = ["binary"] },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
@@ -341,6 +380,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "aiosqlite" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -350,12 +390,15 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosmtplib", specifier = ">=3.0.0" },
+    { name = "aiosqlite", marker = "extra == 'dev'", specifier = ">=0.20.0" },
     { name = "alembic", specifier = ">=1.14.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
+    { name = "boto3", specifier = ">=1.34.0" },
     { name = "fastapi", specifier = ">=0.115.6" },
     { name = "hotosm-auth", extras = ["fastapi"], specifier = "==0.2.12" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.1" },
+    { name = "pillow", specifier = ">=11.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
@@ -448,6 +491,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -529,6 +581,77 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/ac8f99618ffd3dde21db0f4d4b1d2ab00c0880595bfd17df103f7f39fd0c/pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9", size = 6266838, upload-time = "2026-07-01T11:54:11.71Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/51/8b08617af3ad95e33ce6d7dd2c99ed6c8298f7fb131636303956be022e25/pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c", size = 6344383, upload-time = "2026-07-01T11:54:15.756Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
+    { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
+    { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ac/31fb64e1e7efb5a4b50cd3d92049ba89ac6e4d8d3bb6a74e15048ca3353e/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89", size = 4161684, upload-time = "2026-07-01T11:54:25.934Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b4/9805e23d2b4d77842b468513841fda254ee42f0289d25088340e4ff46e2d/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace", size = 4255487, upload-time = "2026-07-01T11:54:27.935Z" },
+    { url = "https://files.pythonhosted.org/packages/df/39/ecf519435a200c693fe053a6ee4d835b41cf963a4dfc2551c4e637cb2a71/pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec", size = 3696433, upload-time = "2026-07-01T11:54:29.813Z" },
+    { url = "https://files.pythonhosted.org/packages/42/92/2fc3ffad878ae8dd5469ec1bc8eb83b71f48e13efdf68f02709003982a32/pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66", size = 5345889, upload-time = "2026-07-01T11:54:31.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/76/8803c13605b763d33d156c4678fc77f8443389c0c51c8aef707bb02015f4/pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35", size = 4780109, upload-time = "2026-07-01T11:54:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65", size = 6263736, upload-time = "2026-07-01T11:54:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3", size = 6937129, upload-time = "2026-07-01T11:54:38.216Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4d/105627a13300c5e0df1d174230b32fd1273062c96f7745fd552b945d1e1d/pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a", size = 6339562, upload-time = "2026-07-01T11:54:40.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/1d/f13de01a553988ab895ba1c722e06cf3144d4f57656fd5b81b6d881f1179/pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e", size = 7049439, upload-time = "2026-07-01T11:54:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f9/066794cca041b969964f779ee5fa66a9498bbf34248ac39c5d7954e4198f/pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f", size = 6473287, upload-time = "2026-07-01T11:54:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/7a58e61d62be561da3a356fe2384d4059a6345fc130e23ef1c36a5b81d24/pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8", size = 7239691, upload-time = "2026-07-01T11:54:47.141Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b0/c4ed4f0ef8f8fa5ee8351537db6650bb8189f7e118842978dd6589065692/pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b", size = 2568185, upload-time = "2026-07-01T11:54:49.137Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/01/001f65b68192f0228cc1dbbc8d2530ab5d58b61037ba0587f946fea607cd/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9cf95fe4d0f84c82d282745d9bb08ad9f926efa00be4697e767b814ce40d4330", size = 4161736, upload-time = "2026-07-01T11:54:51.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d2/0219746d0fd16fc8a84498e79452375be3797d3ce4044596ce565164b84f/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:8728f216dcdb6e6d555cf971cb34076139ad74b31fc2c14da4fafc741c5f6217", size = 4255435, upload-time = "2026-07-01T11:54:53.414Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/02/8d0bc62ef0302318c46ff2a512822d2610e81c7aa46c9b3abe6cbaca5ad0/pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930", size = 3696262, upload-time = "2026-07-01T11:54:55.739Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e2/73c77d218410b14f5f2d565e8a998d5317b7b9c75368d29985139f7a46f0/pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8", size = 5350344, upload-time = "2026-07-01T11:54:57.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0", size = 4780131, upload-time = "2026-07-01T11:54:59.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/9d/8b2c807dbef61a5197c047afe99823787eb66f63daf9fb2432f91d6f0462/pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321", size = 6263757, upload-time = "2026-07-01T11:55:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/c85361f65dbe00eea8576ee467c768d25129989efb76e94f205e9ca9bb46/pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b", size = 6936962, upload-time = "2026-07-01T11:55:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7e/e483414b35800b86b6f08dbbc7803fb5cd52c4d6f897f47d53ea2c7e6f65/pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198", size = 6339171, upload-time = "2026-07-01T11:55:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/68c491844841ede6bed70189546b3ee9731cf9f2cbad396faff5e1ccba45/pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130", size = 7048116, upload-time = "2026-07-01T11:55:08.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/34/77f3f793fed8efc7d243f21b33c5a3f0d1c97ee70346d3db855587e155ff/pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a", size = 6467209, upload-time = "2026-07-01T11:55:10.408Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e0/492879f69d94f91f60fc8cd05ba03650e9520afebb2fb7aa12777d7c7f38/pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d", size = 7237707, upload-time = "2026-07-01T11:55:12.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ac/6b11f2875f1c2ac040d84e1bbf9cf22a88038f901ca1037898b280b38365/pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838", size = 2565995, upload-time = "2026-07-01T11:55:14.736Z" },
+    { url = "https://files.pythonhosted.org/packages/52/69/c2208e56af9bfc1913afb24020297a691eb1d4ef688474c8a04913f65e04/pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e", size = 5352503, upload-time = "2026-07-01T11:55:17.076Z" },
+    { url = "https://files.pythonhosted.org/packages/07/70/e5686d753e898a45d778ff1718dba8516ead6ab6b95d85fc8c4b70650cf2/pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17", size = 4782956, upload-time = "2026-07-01T11:55:19.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/37/25c6692f06927ee973ff18c8d9ee98ad0b4d84ee67a09610c2dd1447958e/pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385", size = 6322855, upload-time = "2026-07-01T11:55:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/91/420637fcb8f1bc11029e403b4538e6694744428d8246118e45719f944556/pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c", size = 6989642, upload-time = "2026-07-01T11:55:24.006Z" },
+    { url = "https://files.pythonhosted.org/packages/10/08/b94d7811281ccf0d143a1cf768d1c49e1e54af63e7b708ab2ee3eb87face/pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d", size = 6391281, upload-time = "2026-07-01T11:55:26.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/87/24233f785f55474dc02ce3e739c5528a77e3a862e9333d1dd7a25cc31f70/pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931", size = 7096716, upload-time = "2026-07-01T11:55:28.318Z" },
+    { url = "https://files.pythonhosted.org/packages/23/26/fcb2f6e37175b04f53570b59937867e2b80ee1685e744023153028fc14f9/pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7", size = 6474125, upload-time = "2026-07-01T11:55:30.956Z" },
+    { url = "https://files.pythonhosted.org/packages/90/de/3634abee5f1c9e13c56787b7d5517b0ba8d6de51700b95578cf338349c9f/pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c", size = 7242939, upload-time = "2026-07-01T11:55:34.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2a/fd13f8eb24de5714a6eb444a3d67e2842c6c576e159a43793adf23051351/pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45", size = 2567506, upload-time = "2026-07-01T11:55:35.988Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/dc/8fdce34ec725a33c81c6ba122b904d6b9024e50ea9ac7bede62fab54506c/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:0feb2e9d6ad6c9e3c06effe9d00f3f1e618a6643273576b016f591e9315a7139", size = 4162063, upload-time = "2026-07-01T11:55:37.941Z" },
+    { url = "https://files.pythonhosted.org/packages/76/66/2044b9a63d3b84ff048228dfcb7cd9bf0df983e8470971bf7d4c57b693de/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:9e881fca225083806662a5c43d627d215f258ff43c890f831966c7d7ba9c7402", size = 4255549, upload-time = "2026-07-01T11:55:40.022Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7e/1f67e6f4ece6b582ee4b539decbcc9f848dc245a93ed8cd7338bafef72f1/pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c", size = 3696331, upload-time = "2026-07-01T11:55:41.98Z" },
+    { url = "https://files.pythonhosted.org/packages/12/40/d306fc2c8e4d45d7f175c77edca7063be7b86fe7fe6e68f4353bf71d808c/pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f", size = 5350370, upload-time = "2026-07-01T11:55:44.028Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/44/668fb1437e8ce420f62d6106eb66e44a5971602a4d794615bdf79315d82d/pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701", size = 4780147, upload-time = "2026-07-01T11:55:46.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/08/93fa2e70e30a2d81547e481b6ee2bb9522117221fb1e0ce4b5df70967677/pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace", size = 6273659, upload-time = "2026-07-01T11:55:48.264Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/6d/043e96ff814fc31a33077e4cba86082167db520c93632afdf2042febbb0c/pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4", size = 6947439, upload-time = "2026-07-01T11:55:50.503Z" },
+    { url = "https://files.pythonhosted.org/packages/af/92/ba71d2ee2ac0edf3fa33bd9d5ee9ee080da70b1766f3ca3934f9938ddac9/pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39", size = 6353577, upload-time = "2026-07-01T11:55:52.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ce/e63064e2122923ff687c8ad792d0d736a7b3920a56a46982e81a7fdd25d6/pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71", size = 7060394, upload-time = "2026-07-01T11:55:55.149Z" },
+    { url = "https://files.pythonhosted.org/packages/54/76/a09cc3ccc8d773a7283d34c38bec1708f9e3cc932093cbc4c5e71ac4060b/pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827", size = 6467375, upload-time = "2026-07-01T11:55:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/03/1846c49ba3b1d5550392a4bbd06d6fb4578e1cd91a803198b5c90f5f7d53/pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5", size = 7237048, upload-time = "2026-07-01T11:55:59.975Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/bb/89f35dcc79610423f9f195504d7def7f0d1416a711541b42867e25fe3412/pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658", size = 2566006, upload-time = "2026-07-01T11:56:02.143Z" },
+    { url = "https://files.pythonhosted.org/packages/30/88/707027ba09942dfa2c28759b5c222d769290a41c6d20ea60ec250801941f/pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf", size = 5352509, upload-time = "2026-07-01T11:56:04.2Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6d/00352fa25332c2569cd387851f568cc5a4b75a9adbfb37ac4fbce4c02eec/pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64", size = 4783167, upload-time = "2026-07-01T11:56:06.631Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/9e049dfa21af7c22427275720e2490267ba8138120add5c4c574deb69782/pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e", size = 6329237, upload-time = "2026-07-01T11:56:08.868Z" },
+    { url = "https://files.pythonhosted.org/packages/36/16/cf6eeaae8d0fce8dd390a33437cf68c5d5bd73834a2bc6e2f14efda0ab45/pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777", size = 6997047, upload-time = "2026-07-01T11:56:11.379Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/69/dbf769bdd55f48bf5733cac28edc6364ffaa072ec9ba336266e4fe66be55/pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1", size = 6400440, upload-time = "2026-07-01T11:56:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e1/ffc9cfc2eea0d178da8018e18e959301ad9d6bc9f3edb7181e748a474b97/pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9", size = 7105895, upload-time = "2026-07-01T11:56:16.575Z" },
+    { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
 ]
 
 [[package]]
@@ -899,6 +1022,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -986,6 +1121,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,15 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import LoginPage from './pages/LoginPage';
-import AdminPage from './pages/AdminPage';
-import ProfilePage from './pages/ProfilePage';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
 import { LanguageProvider } from './contexts/LanguageContext';
+import AccountLayout from './layouts/AccountLayout';
+import AcceptInvitePage from './pages/AcceptInvitePage';
+import AdminPage from './pages/AdminPage';
+import LoginPage from './pages/LoginPage';
+import OrganizationDetailPage from './pages/OrganizationDetailPage';
+import OrganizationsPage from './pages/OrganizationsPage';
+import ProfilePage from './pages/ProfilePage';
+import TeamDetailPage from './pages/TeamDetailPage';
+import TeamsPage from './pages/TeamsPage';
 
 function App() {
   return (
@@ -11,11 +17,24 @@ function App() {
       <AuthProvider>
         <BrowserRouter basename="/app">
           <Routes>
-            {/* Root path serves the login page */}
+            {/* Root path serves the login page (outside the account chrome) */}
             <Route path="/" element={<LoginPage />} />
-            {/* Profile page for user settings */}
-            <Route path="/profile" element={<ProfilePage />} />
-            {/* Admin page for managing user mappings */}
+
+            {/* Account section: shared sidebar + top chrome via AccountLayout */}
+            <Route element={<AccountLayout />}>
+              <Route path="/profile" element={<ProfilePage />} />
+              <Route path="/organizations" element={<OrganizationsPage />} />
+              <Route
+                path="/organizations/:id"
+                element={<OrganizationDetailPage />}
+              />
+              <Route path="/teams" element={<TeamsPage />} />
+              <Route path="/teams/:id" element={<TeamDetailPage />} />
+              {/* Accepts an organization invitation from ?token= */}
+              <Route path="/invite" element={<AcceptInvitePage />} />
+            </Route>
+
+            {/* Admin page keeps its own full-width chrome */}
             <Route path="/admin" element={<AdminPage />} />
           </Routes>
         </BrowserRouter>

--- a/frontend/src/components/GroupCard.tsx
+++ b/frontend/src/components/GroupCard.tsx
@@ -1,0 +1,64 @@
+import { Link } from 'react-router-dom';
+import type { GroupSummary } from '../types/groups';
+import StatusBadge from './StatusBadge';
+
+// Deterministic accent color for the initial-avatar when there's no logo.
+const AVATAR_COLORS = [
+  'bg-hot-red-500',
+  'bg-emerald-500',
+  'bg-blue-500',
+  'bg-amber-500',
+  'bg-violet-500',
+  'bg-pink-500',
+  'bg-teal-500',
+];
+
+function colorFor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) >>> 0;
+  }
+  return AVATAR_COLORS[hash % AVATAR_COLORS.length];
+}
+
+interface Props {
+  group: GroupSummary;
+  to: string;
+  showStatus?: boolean;
+}
+
+function GroupCard({ group, to, showStatus }: Props) {
+  return (
+    <Link
+      to={to}
+      className="group flex items-center gap-4 bg-white rounded-xl border border-hot-gray-200 p-4 hover:shadow-lg hover:border-hot-red-300 hover:-translate-y-0.5 transition-all"
+    >
+      {group.avatar_url ? (
+        <img
+          src={group.avatar_url}
+          alt=""
+          className="w-12 h-12 rounded-full object-cover flex-shrink-0 border border-hot-gray-100"
+        />
+      ) : (
+        <div
+          className={`w-12 h-12 rounded-full flex items-center justify-center text-white text-lg font-semibold flex-shrink-0 ${colorFor(
+            group.name,
+          )}`}
+        >
+          {group.name.charAt(0).toUpperCase()}
+        </div>
+      )}
+      <div className="flex-1 min-w-0">
+        <h3 className="font-semibold text-hot-gray-900 truncate group-hover:text-hot-red-600 transition-colors">
+          {group.name}
+        </h3>
+        {group.role && (
+          <p className="text-xs text-hot-gray-500 capitalize">{group.role}</p>
+        )}
+      </div>
+      {showStatus && <StatusBadge status={group.status} />}
+    </Link>
+  );
+}
+
+export default GroupCard;

--- a/frontend/src/components/MembersPanel.tsx
+++ b/frontend/src/components/MembersPanel.tsx
@@ -1,0 +1,257 @@
+import { type ReactNode, useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useLanguage } from '../contexts/LanguageContext';
+import type { GroupMember, MemberRole, MembersResponse } from '../types/groups';
+import { backendUrl, readError } from '../utils/api';
+
+const PAGE_SIZE = 20;
+
+interface MembersPanelProps {
+  groupId: string;
+  // The viewer's role in this group (from GroupResponse.role)
+  viewerRole: MemberRole | null;
+  // Called after the current user leaves the group
+  onLeft: () => void;
+  // Renders the add/invite UI (differs between teams and organizations).
+  // Receives a callback to refresh the member list after a change.
+  renderAdd?: (onChanged: () => void) => ReactNode;
+}
+
+// Member list with role management shared by team and organization detail pages.
+function MembersPanel({
+  groupId,
+  viewerRole,
+  onLeft,
+  renderAdd,
+}: MembersPanelProps) {
+  const { t } = useLanguage();
+  const navigate = useNavigate();
+
+  const [members, setMembers] = useState<GroupMember[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+
+  const canChangeRoles = viewerRole === 'owner';
+  const canManage = viewerRole === 'owner' || viewerRole === 'manager';
+
+  const goLogin = useCallback(() => {
+    navigate('/?return_to=' + encodeURIComponent(window.location.href));
+  }, [navigate]);
+
+  const fetchMembers = useCallback(async () => {
+    try {
+      setError(null);
+      const response = await fetch(
+        `${backendUrl}/groups/${groupId}/members?page=${page}&page_size=${PAGE_SIZE}`,
+        { credentials: 'include' },
+      );
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      const data: MembersResponse = await response.json();
+      setMembers(data.items || []);
+      setTotal(data.total || 0);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  }, [groupId, page, goLogin]);
+
+  // Identify the current user to show "Leave" and hide self-targeted actions
+  useEffect(() => {
+    const fetchMe = async () => {
+      try {
+        const response = await fetch(`${backendUrl}/profile/me`, {
+          credentials: 'include',
+        });
+        if (response.ok) {
+          const data = await response.json();
+          setCurrentUserId(data.hanko_user_id || null);
+        }
+      } catch {
+        // Non-critical
+      }
+    };
+    fetchMe();
+  }, []);
+
+  useEffect(() => {
+    fetchMembers();
+  }, [fetchMembers]);
+
+  const handleChangeRole = async (member: GroupMember, role: MemberRole) => {
+    if (role === member.role) return;
+    if (role === 'owner' && !window.confirm(t('transferOwnershipConfirm')))
+      return;
+    try {
+      const response = await fetch(
+        `${backendUrl}/groups/${groupId}/members/${member.hanko_user_id}`,
+        {
+          method: 'PATCH',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ role }),
+        },
+      );
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      await fetchMembers();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  const handleRemove = async (member: GroupMember, isSelf: boolean) => {
+    const confirmMsg = isSelf ? t('leaveGroupConfirm') : t('removeMemberConfirm');
+    if (!window.confirm(confirmMsg)) return;
+    try {
+      const response = await fetch(
+        `${backendUrl}/groups/${groupId}/members/${member.hanko_user_id}`,
+        { method: 'DELETE', credentials: 'include' },
+      );
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      if (isSelf) {
+        onLeft();
+      } else {
+        await fetchMembers();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  const memberName = (m: GroupMember) => {
+    const full = `${m.first_name || ''} ${m.last_name || ''}`.trim();
+    return full || m.email || m.hanko_user_id;
+  };
+
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="bg-hot-red-50 border border-hot-red-200 text-hot-red-700 px-4 py-3 rounded-lg">
+          {error}
+        </div>
+      )}
+
+      {canManage && renderAdd && renderAdd(fetchMembers)}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="animate-spin rounded-full h-8 w-8 border-4 border-hot-red-600 border-t-transparent"></div>
+        </div>
+      ) : members.length === 0 ? (
+        <p className="text-sm text-hot-gray-500 py-6 text-center">
+          {t('noMembers')}
+        </p>
+      ) : (
+        <div className="divide-y divide-hot-gray-200">
+          {members.map((member) => {
+            const isSelf = member.hanko_user_id === currentUserId;
+            return (
+              <div
+                key={member.hanko_user_id}
+                className="flex items-center justify-between py-3 gap-3"
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <img
+                    src={
+                      member.picture_url ||
+                      'https://www.gravatar.com/avatar/?d=identicon&s=64'
+                    }
+                    alt=""
+                    className="w-9 h-9 rounded-full object-cover border border-hot-gray-200 flex-shrink-0"
+                  />
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-hot-gray-900 truncate">
+                      {memberName(member)}
+                    </p>
+                    <p className="text-xs text-hot-gray-400">
+                      {t('memberSince')}{' '}
+                      {new Date(member.created_at).toLocaleDateString()}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  {canChangeRoles && !isSelf ? (
+                    <select
+                      value={member.role}
+                      onChange={(e) =>
+                        handleChangeRole(member, e.target.value as MemberRole)
+                      }
+                      className="text-xs border border-hot-gray-300 rounded px-2 py-1 bg-white focus:outline-none focus:border-hot-red-400"
+                    >
+                      <option value="member">{t('roleMember')}</option>
+                      <option value="manager">{t('roleManager')}</option>
+                      <option value="owner">{t('roleOwner')}</option>
+                    </select>
+                  ) : (
+                    <span className="text-xs px-2 py-1 rounded bg-hot-gray-100 text-hot-gray-600">
+                      {member.role === 'owner'
+                        ? t('roleOwner')
+                        : member.role === 'manager'
+                          ? t('roleManager')
+                          : t('roleMember')}
+                    </span>
+                  )}
+
+                  {isSelf ? (
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(member, true)}
+                      className="btn-secondary-small"
+                    >
+                      {t('leaveGroup')}
+                    </button>
+                  ) : (
+                    canManage && (
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(member, false)}
+                        className="btn-danger-small"
+                      >
+                        {t('removeMember')}
+                      </button>
+                    )
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex justify-center items-center gap-4 pt-2">
+          <button
+            type="button"
+            onClick={() => setPage((p) => p - 1)}
+            disabled={page === 1}
+            className="btn-secondary-small disabled:opacity-50"
+          >
+            {t('previous')}
+          </button>
+          <span className="text-sm text-hot-gray-500">
+            {page} / {totalPages}
+          </span>
+          <button
+            type="button"
+            onClick={() => setPage((p) => p + 1)}
+            disabled={page === totalPages}
+            className="btn-secondary-small disabled:opacity-50"
+          >
+            {t('next')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MembersPanel;

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -1,0 +1,25 @@
+import { useLanguage } from '../contexts/LanguageContext';
+
+// Colored pill reflecting a group's approval status
+// (pending / approved / active / rejected).
+function StatusBadge({ status }: { status: string }) {
+  const { t } = useLanguage();
+
+  const styles: Record<string, string> = {
+    pending: 'badge-warning',
+    approved: 'badge-success',
+    active: 'badge-success',
+    rejected: 'bg-hot-red-100 text-hot-red-700',
+  };
+  const labels: Record<string, string> = {
+    pending: t('statusPending'),
+    approved: t('statusApproved'),
+    active: t('statusActive'),
+    rejected: t('statusRejected'),
+  };
+
+  const cls = styles[status] || 'bg-hot-gray-100 text-hot-gray-600';
+  return <span className={`badge ${cls}`}>{labels[status] || status}</span>;
+}
+
+export default StatusBadge;

--- a/frontend/src/hooks/useRoles.ts
+++ b/frontend/src/hooks/useRoles.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { backendUrl } from '../utils/api';
+
+export interface Roles {
+  isAdmin: boolean;
+  isAccountManager: boolean;
+  loading: boolean;
+}
+
+// Fetches the current user's platform roles once (GET /me/roles).
+// Defaults to no privileges while loading or on error.
+export function useRoles(): Roles {
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [isAccountManager, setIsAccountManager] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchRoles = async () => {
+      try {
+        const response = await fetch(`${backendUrl}/me/roles`, {
+          credentials: 'include',
+        });
+        if (response.ok) {
+          const data = await response.json();
+          if (!cancelled) {
+            setIsAdmin(!!data.is_admin);
+            setIsAccountManager(!!data.is_account_manager);
+          }
+        }
+      } catch {
+        // Keep defaults (no privileges) on failure
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchRoles();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { isAdmin, isAccountManager, loading };
+}

--- a/frontend/src/layouts/AccountLayout.tsx
+++ b/frontend/src/layouts/AccountLayout.tsx
@@ -1,0 +1,90 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import '@hotosm/tool-menu';
+import hotLogo from '../assets/images/hot-logo.svg';
+import { useLanguage } from '../contexts/LanguageContext';
+import { useRoles } from '../hooks/useRoles';
+
+// Shared chrome for the account section: top bar with the HOT logo + tool menu
+// and a left sidebar with navigation. The page content renders in <Outlet/>.
+function AccountLayout() {
+  const { t, currentLanguage } = useLanguage();
+  const { isAdmin, isAccountManager } = useRoles();
+
+  const navClass = ({ isActive }: { isActive: boolean }) =>
+    `block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+      isActive
+        ? 'bg-hot-red-50 text-hot-red-600'
+        : 'text-hot-gray-700 hover:bg-hot-gray-50'
+    }`;
+
+  // Admin is a superuser area: styled distinctly (amber + shield) so it clearly
+  // reads as elevated access, separate from the regular account nav.
+  const adminNavClass = ({ isActive }: { isActive: boolean }) =>
+    `flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-semibold transition-colors ${
+      isActive
+        ? 'bg-amber-100 text-amber-800'
+        : 'text-amber-700 hover:bg-amber-50'
+    }`;
+
+  return (
+    <div className="min-h-screen bg-hot-gray-50">
+      {/* Top chrome (logo + tool menu), replaces each page's own header */}
+      <header className="bg-white shadow-sm">
+        <div className="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+          <img src={hotLogo} alt="HOT" className="h-10" />
+          <hotosm-tool-menu lang={currentLanguage} />
+        </div>
+      </header>
+
+      <div className="max-w-6xl mx-auto px-4 py-8 flex flex-col md:flex-row gap-6">
+        {/* Sidebar */}
+        <aside className="md:w-56 flex-shrink-0">
+          <div className="bg-white rounded-xl shadow-xl p-4">
+            <h2 className="text-xs font-semibold uppercase tracking-wide text-hot-gray-500 px-3 mb-3">
+              {t('hotAccount')}
+            </h2>
+            <nav className="space-y-1">
+              <NavLink to="/profile" className={navClass}>
+                {t('navProfile')}
+              </NavLink>
+              <NavLink to="/organizations" className={navClass}>
+                {t('navOrganizations')}
+              </NavLink>
+              <NavLink to="/teams" className={navClass}>
+                {t('navTeams')}
+              </NavLink>
+              {(isAdmin || isAccountManager) && (
+                <>
+                  <div className="my-2 border-t border-hot-gray-200" />
+                  <NavLink to="/admin" className={adminNavClass}>
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+                      />
+                    </svg>
+                    {t('navAdmin')}
+                  </NavLink>
+                </>
+              )}
+            </nav>
+          </div>
+        </aside>
+
+        {/* Page content */}
+        <main className="flex-1 min-w-0">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export default AccountLayout;

--- a/frontend/src/pages/AcceptInvitePage.tsx
+++ b/frontend/src/pages/AcceptInvitePage.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { useLanguage } from '../contexts/LanguageContext';
+import { backendUrl, readError } from '../utils/api';
+
+type Status = 'loading' | 'success' | 'error';
+
+// Handles /invite?token=... — accepts an organization invitation on mount.
+function AcceptInvitePage() {
+  const { t } = useLanguage();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
+
+  const [status, setStatus] = useState<Status>('loading');
+  const [error, setError] = useState<string | null>(null);
+  // Guard against React 18/19 StrictMode double-invoking the effect
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (attempted.current) return;
+    attempted.current = true;
+
+    if (!token) {
+      setError(t('noInviteToken'));
+      setStatus('error');
+      return;
+    }
+
+    const accept = async () => {
+      try {
+        const response = await fetch(
+          `${backendUrl}/me/invitations/${token}/accept`,
+          { method: 'POST', credentials: 'include' },
+        );
+        if (response.status === 401) {
+          navigate('/?return_to=' + encodeURIComponent(window.location.href));
+          return;
+        }
+        if (!response.ok) throw new Error(await readError(response));
+        setStatus('success');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : t('inviteFailed'));
+        setStatus('error');
+      }
+    };
+
+    accept();
+  }, [token, navigate, t]);
+
+  return (
+    <div className="max-w-md mx-auto">
+      <div className="bg-white rounded-xl shadow-xl p-8 text-center">
+        {status === 'loading' && (
+          <>
+            <div className="animate-spin rounded-full h-10 w-10 border-4 border-hot-red-600 border-t-transparent mx-auto mb-4"></div>
+            <p className="text-hot-gray-600">{t('acceptingInvite')}</p>
+          </>
+        )}
+
+        {status === 'success' && (
+          <>
+            <h1 className="text-lg font-semibold text-hot-gray-900 mb-2">
+              {t('inviteAccepted')}
+            </h1>
+            <Link
+              to="/organizations"
+              className="btn-primary-hot inline-block w-auto px-6 py-2 text-sm mt-2"
+            >
+              {t('goToGroup')}
+            </Link>
+          </>
+        )}
+
+        {status === 'error' && (
+          <>
+            <h1 className="text-lg font-semibold text-hot-red-600 mb-2">
+              {t('inviteFailed')}
+            </h1>
+            {error && <p className="text-sm text-hot-gray-600 mb-4">{error}</p>}
+            <Link
+              to="/organizations"
+              className="btn-secondary-hot inline-block w-auto px-6 py-2 text-sm"
+            >
+              {t('navOrganizations')}
+            </Link>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default AcceptInvitePage;

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -13,6 +13,9 @@ import {
   Cell,
 } from 'recharts';
 import hotLogo from '../assets/images/hot-logo.svg';
+import { useRoles } from '../hooks/useRoles';
+import { readError } from '../utils/api';
+import type { GroupResponse } from '../types/groups';
 
 interface Mapping {
   hanko_user_id: string;
@@ -78,6 +81,14 @@ interface SearchUser {
   apps: string[];
   created_at: string;
   last_login: string | null;
+  // Optional platform role, if provided by the backend (e.g. 'account_manager')
+  role?: string;
+}
+
+interface AccountManager {
+  hanko_user_id: string;
+  granted_by: string;
+  granted_at: string;
 }
 
 interface SearchResult {
@@ -217,10 +228,14 @@ const ProgressRing = ({
   );
 };
 
+type AdminTab = 'dashboard' | 'mappings' | 'users' | 'organizations';
+
 function AdminPage() {
   const navigate = useNavigate();
-  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
-  const [activeTab, setActiveTab] = useState<'dashboard' | 'mappings'>('dashboard');
+  // Platform roles decide which tabs are visible (admin vs account manager)
+  const { isAdmin, isAccountManager, loading: rolesLoading } = useRoles();
+  const [activeTab, setActiveTab] = useState<AdminTab>('dashboard');
+  const [tabInitialized, setTabInitialized] = useState(false);
 
   // Dashboard state
   const [period, setPeriod] = useState<Period>('month');
@@ -260,26 +275,36 @@ function AdminPage() {
   const [searchTotalPages, setSearchTotalPages] = useState(0);
   const [searchLoading, setSearchLoading] = useState(false);
 
+  // Account managers (users tab) — set of hanko_user_ids that are AMs
+  const [accountManagers, setAccountManagers] = useState<Set<string>>(new Set());
+
+  // Pending organizations (organizations tab)
+  const [pendingOrgs, setPendingOrgs] = useState<GroupResponse[]>([]);
+  const [selectedOrg, setSelectedOrg] = useState<GroupResponse | null>(null);
+  const [orgsLoading, setOrgsLoading] = useState(false);
+  const [orgsError, setOrgsError] = useState<string | null>(null);
+
   const backendUrl = import.meta.env.VITE_BACKEND_URL || '/api';
 
-  // Check if user is admin
+  // Which tabs the current user can see (order matters: first visible = default)
+  const visibleTabs: AdminTab[] = [];
+  if (isAdmin) visibleTabs.push('dashboard', 'mappings');
+  if (isAdmin || isAccountManager) visibleTabs.push('users', 'organizations');
+
+  // Once roles resolve, land on the first visible tab (honoring ?tab=).
+  // An account-manager-only user starts on 'users', not 'dashboard'.
   useEffect(() => {
-    const checkAdmin = async () => {
-      try {
-        const response = await fetch(`${backendUrl}/admin/check`, {
-          credentials: 'include',
-        });
-        if (response.ok) {
-          setIsAdmin(true);
-        } else {
-          setIsAdmin(false);
-        }
-      } catch {
-        setIsAdmin(false);
-      }
-    };
-    checkAdmin();
-  }, [backendUrl]);
+    if (rolesLoading || tabInitialized) return;
+    const requested = new URLSearchParams(window.location.search).get(
+      'tab'
+    ) as AdminTab | null;
+    if (requested && visibleTabs.includes(requested)) {
+      setActiveTab(requested);
+    } else if (!visibleTabs.includes(activeTab) && visibleTabs.length > 0) {
+      setActiveTab(visibleTabs[0]);
+    }
+    setTabInitialized(true);
+  }, [rolesLoading, tabInitialized, activeTab, visibleTabs]);
 
   // Build query params for period filter
   const buildPeriodParams = () => {
@@ -408,9 +433,9 @@ function AdminPage() {
     fetchMappings();
   }, [isAdmin, activeTab, selectedApp, page, backendUrl]);
 
-  // Search users function
+  // Search users function (available to admins and account managers)
   const handleSearch = async (newPage = 1) => {
-    if (!isAdmin) return;
+    if (!isAdmin && !isAccountManager) return;
 
     setSearchLoading(true);
     setSearchPage(newPage);
@@ -445,12 +470,57 @@ function AdminPage() {
     }
   };
 
-  // Initial search on mount
+  // Run the user search when the Users tab opens (admins and account managers)
   useEffect(() => {
-    if (isAdmin && activeTab === 'dashboard') {
+    if ((isAdmin || isAccountManager) && activeTab === 'users') {
       handleSearch(1);
     }
-  }, [isAdmin, activeTab]);
+  }, [isAdmin, isAccountManager, activeTab]);
+
+  // Load current account managers to flag them in the users table.
+  // Admin-only endpoint — skip for account-manager-only users to avoid 403.
+  useEffect(() => {
+    if (!isAdmin || activeTab !== 'users') return;
+    const fetchAccountManagers = async () => {
+      try {
+        const response = await fetch(`${backendUrl}/admin/account-managers`, {
+          credentials: 'include',
+        });
+        if (response.ok) {
+          const data: AccountManager[] = await response.json();
+          setAccountManagers(new Set(data.map((am) => am.hanko_user_id)));
+        }
+      } catch {
+        // Non-critical: role column just falls back to '—'
+      }
+    };
+    fetchAccountManagers();
+  }, [isAdmin, activeTab, backendUrl]);
+
+  // Load pending organizations for the Organizations tab
+  const fetchPendingOrgs = async () => {
+    setOrgsLoading(true);
+    setOrgsError(null);
+    try {
+      const response = await fetch(
+        `${backendUrl}/admin/organizations?status=pending&page=1&page_size=50`,
+        { credentials: 'include' }
+      );
+      if (!response.ok) throw new Error(await readError(response));
+      const data = await response.json();
+      setPendingOrgs(data.items || []);
+    } catch (err) {
+      setOrgsError(err instanceof Error ? err.message : 'Failed to load organizations');
+    } finally {
+      setOrgsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if ((isAdmin || isAccountManager) && activeTab === 'organizations') {
+      fetchPendingOrgs();
+    }
+  }, [isAdmin, isAccountManager, activeTab]);
 
   const handleDeleteMapping = async (hankoUserId: string) => {
     if (!confirm('Are you sure you want to delete this mapping?')) return;
@@ -510,6 +580,71 @@ function AdminPage() {
     }
   };
 
+  // Grant/revoke the account manager role (admin only)
+  const handleToggleAccountManager = async (userId: string, makeAm: boolean) => {
+    try {
+      const response = await fetch(
+        `${backendUrl}/admin/account-managers/${userId}`,
+        { method: makeAm ? 'PUT' : 'DELETE', credentials: 'include' }
+      );
+      if (!response.ok) throw new Error(await readError(response));
+      setAccountManagers((prev) => {
+        const next = new Set(prev);
+        if (makeAm) next.add(userId);
+        else next.delete(userId);
+        return next;
+      });
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to update role');
+    }
+  };
+
+  // Organization moderation actions (admin / account manager)
+  const handleApproveOrg = async (orgId: string) => {
+    try {
+      const response = await fetch(
+        `${backendUrl}/admin/organizations/${orgId}/approve`,
+        { method: 'POST', credentials: 'include' }
+      );
+      if (!response.ok) throw new Error(await readError(response));
+      setPendingOrgs((prev) => prev.filter((o) => o.id !== orgId));
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to approve');
+    }
+  };
+
+  const handleRejectOrg = async (orgId: string) => {
+    const reason = window.prompt('Reason for rejection (optional):') ?? undefined;
+    try {
+      const response = await fetch(
+        `${backendUrl}/admin/organizations/${orgId}/reject`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reason }),
+        }
+      );
+      if (!response.ok) throw new Error(await readError(response));
+      setPendingOrgs((prev) => prev.filter((o) => o.id !== orgId));
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to reject');
+    }
+  };
+
+  const handleApproveName = async (orgId: string) => {
+    try {
+      const response = await fetch(
+        `${backendUrl}/admin/organizations/${orgId}/approve-name`,
+        { method: 'POST', credentials: 'include' }
+      );
+      if (!response.ok) throw new Error(await readError(response));
+      await fetchPendingOrgs();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to approve name');
+    }
+  };
+
   const formatDate = (dateStr: string) => {
     return new Date(dateStr).toLocaleString();
   };
@@ -521,8 +656,8 @@ function AdminPage() {
 
   const totalPages = Math.ceil(total / 20);
 
-  // Loading admin check
-  if (isAdmin === null) {
+  // Loading roles
+  if (rolesLoading) {
     return (
       <div className="admin-page">
         <div className="admin-loading">
@@ -533,8 +668,8 @@ function AdminPage() {
     );
   }
 
-  // Not admin
-  if (!isAdmin) {
+  // Neither admin nor account manager — no access to the panel at all
+  if (!isAdmin && !isAccountManager) {
     return (
       <div className="admin-page">
         <div className="admin-card admin-error-card">
@@ -574,20 +709,41 @@ function AdminPage() {
         </button>
       </div>
 
-      {/* Tabs */}
+      {/* Tabs — dashboard/mappings are admin-only; users/organizations
+          are also available to account managers */}
       <div className="admin-tabs">
-        <button
-          className={`admin-tab ${activeTab === 'dashboard' ? 'active' : ''}`}
-          onClick={() => setActiveTab('dashboard')}
-        >
-          Dashboard
-        </button>
-        <button
-          className={`admin-tab ${activeTab === 'mappings' ? 'active' : ''}`}
-          onClick={() => setActiveTab('mappings')}
-        >
-          User Mappings
-        </button>
+        {isAdmin && (
+          <button
+            className={`admin-tab ${activeTab === 'dashboard' ? 'active' : ''}`}
+            onClick={() => setActiveTab('dashboard')}
+          >
+            Dashboard
+          </button>
+        )}
+        {isAdmin && (
+          <button
+            className={`admin-tab ${activeTab === 'mappings' ? 'active' : ''}`}
+            onClick={() => setActiveTab('mappings')}
+          >
+            User Mappings
+          </button>
+        )}
+        {(isAdmin || isAccountManager) && (
+          <button
+            className={`admin-tab ${activeTab === 'users' ? 'active' : ''}`}
+            onClick={() => setActiveTab('users')}
+          >
+            Users
+          </button>
+        )}
+        {(isAdmin || isAccountManager) && (
+          <button
+            className={`admin-tab ${activeTab === 'organizations' ? 'active' : ''}`}
+            onClick={() => setActiveTab('organizations')}
+          >
+            Orgs to approve
+          </button>
+        )}
       </div>
 
       {/* Dashboard Tab */}
@@ -831,8 +987,13 @@ function AdminPage() {
             </div>
           </div>
 
-          {/* User Search Section */}
-          <div className="glass-card p-6 mt-6">
+        </div>
+      )}
+
+      {/* Users Tab — user search + account manager management */}
+      {(isAdmin || isAccountManager) && activeTab === 'users' && (
+        <div className="dashboard-content">
+          <div className="glass-card p-6">
             <h3 className="text-lg font-semibold text-gray-800 mb-1 flex items-center gap-2">
               <svg className="w-5 h-5 text-hot-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -913,6 +1074,8 @@ function AdminPage() {
                     <th className="text-left py-3 px-2 font-semibold text-gray-600">Onboarded</th>
                     <th className="text-left py-3 px-2 font-semibold text-gray-600">Registered</th>
                     <th className="text-left py-3 px-2 font-semibold text-gray-600">Last Login</th>
+                    <th className="text-left py-3 px-2 font-semibold text-gray-600">Role</th>
+                    <th className="text-left py-3 px-2 font-semibold text-gray-600">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -926,11 +1089,13 @@ function AdminPage() {
                         <td className="py-3 px-2"><div className="h-4 bg-gray-200 rounded w-24"></div></td>
                         <td className="py-3 px-2"><div className="h-4 bg-gray-200 rounded w-20"></div></td>
                         <td className="py-3 px-2"><div className="h-4 bg-gray-200 rounded w-20"></div></td>
+                        <td className="py-3 px-2"><div className="h-4 bg-gray-200 rounded w-24"></div></td>
+                        <td className="py-3 px-2"><div className="h-7 bg-gray-200 rounded w-28"></div></td>
                       </tr>
                     ))
                   ) : searchResults.length === 0 ? (
                     <tr>
-                      <td colSpan={7} className="py-8 text-center text-gray-500">No users found</td>
+                      <td colSpan={9} className="py-8 text-center text-gray-500">No users found</td>
                     </tr>
                   ) : (
                     searchResults.map((user) => (
@@ -1003,6 +1168,33 @@ function AdminPage() {
                         <td className="py-3 px-2 text-gray-600">
                           {user.last_login ? new Date(user.last_login).toLocaleDateString() : <span className="text-gray-400">-</span>}
                         </td>
+                        <td className="py-3 px-2">
+                          {accountManagers.has(user.id) || user.role === 'account_manager' ? (
+                            <span className="text-xs px-2 py-0.5 rounded bg-hot-red-100 text-hot-red-700">account_manager</span>
+                          ) : (
+                            <span className="text-gray-400">—</span>
+                          )}
+                        </td>
+                        <td className="py-3 px-2">
+                          {!isAdmin ? (
+                            // Account Managers see the user list read-only.
+                            <span className="text-gray-400">—</span>
+                          ) : accountManagers.has(user.id) || user.role === 'account_manager' ? (
+                            <button
+                              onClick={() => handleToggleAccountManager(user.id, false)}
+                              className="text-xs px-2 py-1 border border-gray-200 rounded-lg hover:bg-gray-50 whitespace-nowrap"
+                            >
+                              Remove account manager
+                            </button>
+                          ) : (
+                            <button
+                              onClick={() => handleToggleAccountManager(user.id, true)}
+                              className="text-xs px-2 py-1 border border-hot-red-200 text-hot-red-600 rounded-lg hover:bg-hot-red-50 whitespace-nowrap"
+                            >
+                              Make account manager
+                            </button>
+                          )}
+                        </td>
                       </tr>
                     ))
                   )}
@@ -1032,6 +1224,242 @@ function AdminPage() {
                 </button>
               </div>
             )}
+          </div>
+        </div>
+      )}
+
+      {/* Organizations Tab — pending organization approvals */}
+      {(isAdmin || isAccountManager) && activeTab === 'organizations' && (
+        <div className="dashboard-content">
+          <div className="glass-card p-6">
+            <h3 className="text-lg font-semibold text-gray-800 mb-1 flex items-center gap-2">
+              <svg className="w-5 h-5 text-hot-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+              </svg>
+              Pending Organizations
+            </h3>
+            <p className="text-xs text-gray-400 mb-4">Review and approve organization requests</p>
+
+            {orgsError && (
+              <div className="admin-alert admin-alert-error">{orgsError}</div>
+            )}
+
+            {orgsLoading ? (
+              <div className="admin-loading">
+                <div className="spinner"></div>
+                <p>Loading organizations...</p>
+              </div>
+            ) : pendingOrgs.length === 0 ? (
+              <div className="text-center py-8 text-gray-500 text-sm">
+                No pending organizations
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-200">
+                      <th className="text-left py-3 px-2 font-semibold text-gray-600">Name</th>
+                      <th className="text-left py-3 px-2 font-semibold text-gray-600">Contact</th>
+                      <th className="text-left py-3 px-2 font-semibold text-gray-600">Requested</th>
+                      <th className="text-left py-3 px-2 font-semibold text-gray-600">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pendingOrgs.map((org) => (
+                      <tr key={org.id} className="border-b border-gray-100 hover:bg-gray-50">
+                        <td className="py-3 px-2">
+                          <button
+                            type="button"
+                            onClick={() => setSelectedOrg(org)}
+                            className="font-medium text-hot-red-600 hover:underline text-left"
+                          >
+                            {org.name}
+                          </button>
+                          {org.pending_name && (
+                            <div className="text-xs text-gray-500">
+                              Pending name: {org.pending_name}
+                            </div>
+                          )}
+                        </td>
+                        <td className="py-3 px-2 text-gray-600">
+                          {org.contact_email || '—'}
+                        </td>
+                        <td className="py-3 px-2 text-gray-600">
+                          {new Date(org.created_at).toLocaleDateString()}
+                        </td>
+                        <td className="py-3 px-2">
+                          <div className="flex gap-2 flex-wrap">
+                            <button
+                              onClick={() => setSelectedOrg(org)}
+                              className="text-xs px-2 py-1 border border-gray-200 rounded-lg hover:bg-gray-50 whitespace-nowrap"
+                            >
+                              View
+                            </button>
+                            <button
+                              onClick={() => handleApproveOrg(org.id)}
+                              className="btn-success-small"
+                            >
+                              Approve
+                            </button>
+                            <button
+                              onClick={() => handleRejectOrg(org.id)}
+                              className="btn-danger-small"
+                            >
+                              Reject
+                            </button>
+                            {org.pending_name && (
+                              <button
+                                onClick={() => handleApproveName(org.id)}
+                                className="btn-primary-small"
+                              >
+                                Approve name
+                              </button>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Organization detail — review everything before approving */}
+      {selectedOrg && (
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+          onClick={() => setSelectedOrg(null)}
+        >
+          <div
+            className="bg-white rounded-xl shadow-2xl max-w-lg w-full max-h-[90vh] overflow-y-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {selectedOrg.banner_url && (
+              <img
+                src={selectedOrg.banner_url}
+                alt=""
+                className="w-full h-32 object-cover rounded-t-xl"
+              />
+            )}
+            <div className="p-6">
+              <div className="flex items-center gap-3 mb-4">
+                {selectedOrg.avatar_url ? (
+                  <img
+                    src={selectedOrg.avatar_url}
+                    alt=""
+                    className="w-14 h-14 rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="w-14 h-14 rounded-full bg-gray-200 flex items-center justify-center text-gray-500 text-xl font-semibold">
+                    {selectedOrg.name[0]?.toUpperCase()}
+                  </div>
+                )}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-800">
+                    {selectedOrg.name}
+                  </h3>
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-yellow-100 text-yellow-700">
+                    {selectedOrg.status}
+                  </span>
+                </div>
+              </div>
+
+              {selectedOrg.pending_name && (
+                <div className="mb-3 text-sm">
+                  <span className="text-gray-500">Pending name change: </span>
+                  <span className="font-medium">{selectedOrg.pending_name}</span>
+                </div>
+              )}
+
+              <dl className="space-y-3 text-sm mb-6">
+                <div>
+                  <dt className="text-gray-500">Description</dt>
+                  <dd className="text-gray-800 whitespace-pre-wrap">
+                    {selectedOrg.description || '—'}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500">Website</dt>
+                  <dd>
+                    {selectedOrg.website ? (
+                      <a
+                        href={selectedOrg.website}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-hot-red-600 hover:underline break-all"
+                      >
+                        {selectedOrg.website}
+                      </a>
+                    ) : (
+                      '—'
+                    )}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500">Contact email</dt>
+                  <dd className="text-gray-800">
+                    {selectedOrg.contact_email || '—'}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500">Members</dt>
+                  <dd className="text-gray-800">{selectedOrg.members_count}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500">Requested</dt>
+                  <dd className="text-gray-800">
+                    {new Date(selectedOrg.created_at).toLocaleString()}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500">Requested by (user ID)</dt>
+                  <dd className="font-mono text-xs text-gray-600 break-all">
+                    {selectedOrg.created_by}
+                  </dd>
+                </div>
+              </dl>
+
+              <div className="flex gap-2 justify-end flex-wrap">
+                <button
+                  onClick={() => setSelectedOrg(null)}
+                  className="px-4 py-2 text-sm border border-gray-200 rounded-lg hover:bg-gray-50"
+                >
+                  Close
+                </button>
+                {selectedOrg.pending_name && (
+                  <button
+                    onClick={async () => {
+                      await handleApproveName(selectedOrg.id);
+                      setSelectedOrg(null);
+                    }}
+                    className="btn-primary-small"
+                  >
+                    Approve name
+                  </button>
+                )}
+                <button
+                  onClick={async () => {
+                    await handleRejectOrg(selectedOrg.id);
+                    setSelectedOrg(null);
+                  }}
+                  className="btn-danger-small"
+                >
+                  Reject
+                </button>
+                <button
+                  onClick={async () => {
+                    await handleApproveOrg(selectedOrg.id);
+                    setSelectedOrg(null);
+                  }}
+                  className="btn-success-small"
+                >
+                  Approve
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       )}

--- a/frontend/src/pages/OrganizationDetailPage.tsx
+++ b/frontend/src/pages/OrganizationDetailPage.tsx
@@ -1,0 +1,573 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import MembersPanel from '../components/MembersPanel';
+import StatusBadge from '../components/StatusBadge';
+import { useLanguage } from '../contexts/LanguageContext';
+import type {
+  GroupResponse,
+  Invitation,
+  MemberRole,
+} from '../types/groups';
+import { backendUrl, readError } from '../utils/api';
+
+function OrganizationDetailPage() {
+  const { id = '' } = useParams();
+  const navigate = useNavigate();
+  const { t } = useLanguage();
+
+  const [group, setGroup] = useState<GroupResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<'details' | 'members'>('details');
+
+  // Editable details form
+  const [description, setDescription] = useState('');
+  const [contactEmail, setContactEmail] = useState('');
+  const [website, setWebsite] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Name change
+  const [editingName, setEditingName] = useState(false);
+  const [newName, setNewName] = useState('');
+
+  // Invitations (sent) + invite form
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteMessage, setInviteMessage] = useState<string | null>(null);
+  const [inviteRole, setInviteRole] = useState<MemberRole>('member');
+
+  const goLogin = useCallback(() => {
+    navigate('/?return_to=' + encodeURIComponent(window.location.href));
+  }, [navigate]);
+
+  const fetchGroup = useCallback(async () => {
+    try {
+      setError(null);
+      const response = await fetch(`${backendUrl}/groups/${id}`, {
+        credentials: 'include',
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      const data: GroupResponse = await response.json();
+      setGroup(data);
+      setDescription(data.description || '');
+      setContactEmail(data.contact_email || '');
+      setWebsite(data.website || '');
+      setIsPublic(data.is_public);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  }, [id, goLogin]);
+
+  useEffect(() => {
+    fetchGroup();
+  }, [fetchGroup]);
+
+  const canManage = group?.role === 'owner' || group?.role === 'manager';
+  const canDelete = group?.role === 'owner';
+
+  const fetchInvitations = useCallback(async () => {
+    if (!canManage) return;
+    try {
+      const response = await fetch(`${backendUrl}/groups/${id}/invitations`, {
+        credentials: 'include',
+      });
+      if (response.ok) setInvitations(await response.json());
+    } catch {
+      // Non-critical
+    }
+  }, [id, canManage]);
+
+  useEffect(() => {
+    if (activeTab === 'members') fetchInvitations();
+  }, [activeTab, fetchInvitations]);
+
+  const flashSuccess = (msg: string) => {
+    setSuccess(msg);
+    setTimeout(() => setSuccess(null), 3000);
+  };
+
+  const handleSaveDetails = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch(`${backendUrl}/groups/${id}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          description: description || null,
+          contact_email: contactEmail || null,
+          website: website || null,
+          is_public: isPublic,
+        }),
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      setGroup(await response.json());
+      flashSuccess(t('detailsSaved'));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleChangeName = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const response = await fetch(`${backendUrl}/groups/${id}/name-change`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName }),
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      setGroup(await response.json());
+      setEditingName(false);
+      setNewName('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  const handleUpload = async (kind: 'avatar' | 'banner', file: File) => {
+    setError(null);
+    try {
+      const form = new FormData();
+      form.append('file', file);
+      const response = await fetch(`${backendUrl}/groups/${id}/${kind}`, {
+        method: 'PUT',
+        credentials: 'include',
+        body: form,
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      await fetchGroup();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm(t('deleteGroupConfirm'))) return;
+    try {
+      const response = await fetch(`${backendUrl}/groups/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      navigate('/organizations');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  const handleInvite = async (e: React.FormEvent, onChanged: () => void) => {
+    e.preventDefault();
+    setError(null);
+    setInviteMessage(null);
+    const email = inviteEmail;
+    try {
+      const response = await fetch(`${backendUrl}/groups/${id}/invitations`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: inviteEmail, role: inviteRole }),
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      const created = await response.json();
+      setInviteEmail('');
+      setInviteRole('member');
+      setInviteMessage(
+        created.recipient_exists === false
+          ? `Invitation sent to ${email}. They don't have a HOT account yet — they'll need to sign up to accept.`
+          : `Invitation sent to ${email}.`,
+      );
+      await fetchInvitations();
+      onChanged();
+      setTimeout(() => setInviteMessage(null), 8000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  const handleCancelInvite = async (invId: string) => {
+    if (!window.confirm(t('cancelInviteConfirm'))) return;
+    try {
+      const response = await fetch(
+        `${backendUrl}/groups/${id}/invitations/${invId}`,
+        { method: 'DELETE', credentials: 'include' },
+      );
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      setInvitations((prev) => prev.filter((inv) => inv.id !== invId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="animate-spin rounded-full h-12 w-12 border-4 border-hot-red-600 border-t-transparent"></div>
+      </div>
+    );
+  }
+
+  if (!group) {
+    return (
+      <div className="max-w-3xl mx-auto">
+        <div className="bg-hot-red-50 border border-hot-red-200 text-hot-red-700 px-4 py-3 rounded-lg">
+          {error || 'Not found'}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      <button
+        type="button"
+        onClick={() => navigate('/organizations')}
+        className="text-sm text-hot-gray-500 hover:text-hot-red-600 transition-colors"
+      >
+        ← {t('navOrganizations')}
+      </button>
+
+      {error && (
+        <div className="bg-hot-red-50 border border-hot-red-200 text-hot-red-700 px-4 py-3 rounded-lg">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg">
+          {success}
+        </div>
+      )}
+
+      {/* Header with banner + name */}
+      <div className="bg-white rounded-xl shadow-xl overflow-hidden">
+        <div
+          className="h-28 bg-hot-gray-100 bg-cover bg-center"
+          style={
+            group.banner_url
+              ? { backgroundImage: `url(${group.banner_url})` }
+              : undefined
+          }
+        />
+        <div className="p-6">
+          <div className="flex items-center gap-4">
+            <img
+              src={
+                group.avatar_url ||
+                'https://www.gravatar.com/avatar/?d=identicon&s=96'
+              }
+              alt=""
+              className="w-16 h-16 rounded-full object-cover border-2 border-white shadow -mt-12 bg-white"
+            />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <h1 className="text-xl font-semibold text-hot-gray-900">
+                  {group.name}
+                </h1>
+                <StatusBadge status={group.status} />
+              </div>
+              {group.pending_name && (
+                <p className="text-xs text-hot-gray-500 mt-1">
+                  {t('nameChangePending')}: {group.pending_name}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => setActiveTab('details')}
+          className={`admin-tab ${activeTab === 'details' ? 'active' : ''}`}
+        >
+          {t('detailsTab')}
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab('members')}
+          className={`admin-tab ${activeTab === 'members' ? 'active' : ''}`}
+        >
+          {t('membersTab')} ({group.members_count})
+        </button>
+      </div>
+
+      {activeTab === 'details' && (
+        <div className="bg-white rounded-xl shadow-xl p-6 space-y-6">
+          {/* Name change */}
+          <div>
+            <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+              {t('name')}
+            </label>
+            {editingName ? (
+              <form onSubmit={handleChangeName} className="flex gap-2">
+                <input
+                  type="text"
+                  required
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  className="input-field"
+                />
+                <button
+                  type="submit"
+                  className="btn-primary-hot w-auto px-4 py-2 text-sm"
+                >
+                  {t('saveChanges')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setEditingName(false)}
+                  className="btn-secondary-hot w-auto px-4 py-2 text-sm"
+                >
+                  {t('cancel')}
+                </button>
+              </form>
+            ) : (
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-hot-gray-900">{group.name}</span>
+                {canManage && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setNewName(group.name);
+                      setEditingName(true);
+                    }}
+                    className="text-sm text-hot-red-600 hover:underline"
+                  >
+                    {t('changeName')}
+                  </button>
+                )}
+              </div>
+            )}
+            {group.pending_name && (
+              <p className="text-xs text-hot-gray-500 mt-1">
+                {t('nameChangePending')}: {group.pending_name}
+              </p>
+            )}
+          </div>
+
+          {canManage ? (
+            <form onSubmit={handleSaveDetails} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                  {t('contactEmail')}
+                </label>
+                <input
+                  type="email"
+                  value={contactEmail}
+                  onChange={(e) => setContactEmail(e.target.value)}
+                  className="input-field"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                  {t('website')}
+                </label>
+                <input
+                  type="url"
+                  value={website}
+                  onChange={(e) => setWebsite(e.target.value)}
+                  className="input-field"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                  {t('description')}
+                </label>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  rows={3}
+                  className="input-field"
+                />
+              </div>
+              {/* Public-profile toggle hidden until portal public profiles ship.
+                  The is_public state is still submitted (unchanged) so nothing breaks. */}
+
+              {/* Avatar / banner upload */}
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                    {t('avatarLabel')}
+                  </label>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    onChange={(e) =>
+                      e.target.files?.[0] &&
+                      handleUpload('avatar', e.target.files[0])
+                    }
+                    className="text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                    {t('bannerLabel')}
+                  </label>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    onChange={(e) =>
+                      e.target.files?.[0] &&
+                      handleUpload('banner', e.target.files[0])
+                    }
+                    className="text-sm"
+                  />
+                </div>
+              </div>
+
+              <div className="flex items-center justify-between pt-2">
+                <button
+                  type="submit"
+                  disabled={saving}
+                  className="btn-primary-hot w-auto px-4 py-2 text-sm disabled:opacity-50"
+                >
+                  {saving ? t('saving') : t('saveChanges')}
+                </button>
+                {canDelete && (
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    className="btn-danger-small"
+                  >
+                    {t('deleteGroupBtn')}
+                  </button>
+                )}
+              </div>
+            </form>
+          ) : (
+            <dl className="space-y-3 text-sm">
+              <div>
+                <dt className="font-medium text-hot-gray-700">
+                  {t('contactEmail')}
+                </dt>
+                <dd className="text-hot-gray-600">{group.contact_email || '—'}</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-hot-gray-700">
+                  {t('website')}
+                </dt>
+                <dd className="text-hot-gray-600">{group.website || '—'}</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-hot-gray-700">
+                  {t('description')}
+                </dt>
+                <dd className="text-hot-gray-600 whitespace-pre-line">
+                  {group.description || '—'}
+                </dd>
+              </div>
+            </dl>
+          )}
+        </div>
+      )}
+
+      {activeTab === 'members' && (
+        <div className="bg-white rounded-xl shadow-xl p-6">
+          <MembersPanel
+            groupId={id}
+            viewerRole={group.role}
+            onLeft={() => navigate('/organizations')}
+            renderAdd={(onChanged) =>
+              group.status !== 'approved' ? (
+                <div className="text-sm text-hot-gray-500 bg-hot-gray-50 border border-hot-gray-200 rounded-lg px-3 py-2 mb-2">
+                  You can invite members once this organization is approved.
+                </div>
+              ) : (
+                <div className="space-y-4 mb-2">
+                <form
+                  onSubmit={(e) => handleInvite(e, onChanged)}
+                  className="flex flex-wrap items-end gap-2"
+                >
+                  <div className="flex-1 min-w-[180px]">
+                    <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                      {t('addMemberByEmail')}
+                    </label>
+                    <input
+                      type="email"
+                      required
+                      value={inviteEmail}
+                      onChange={(e) => setInviteEmail(e.target.value)}
+                      placeholder="person@example.org"
+                      className="input-field"
+                    />
+                  </div>
+                  <select
+                    value={inviteRole}
+                    onChange={(e) => setInviteRole(e.target.value as MemberRole)}
+                    className="input-field w-auto"
+                  >
+                    <option value="member">{t('roleMember')}</option>
+                    <option value="manager">{t('roleManager')}</option>
+                  </select>
+                  <button
+                    type="submit"
+                    className="btn-primary-hot w-auto px-4 py-2 text-sm"
+                  >
+                    {t('inviteBtn')}
+                  </button>
+                </form>
+
+                {inviteMessage && (
+                  <div className="text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-3 py-2">
+                    {inviteMessage}
+                  </div>
+                )}
+
+                {invitations.length > 0 && (
+                  <div>
+                    <h3 className="text-xs font-semibold uppercase tracking-wide text-hot-gray-500 mb-2">
+                      {t('sentInvitations')}
+                    </h3>
+                    <div className="divide-y divide-hot-gray-100">
+                      {invitations.map((inv) => (
+                        <div
+                          key={inv.id}
+                          className="flex items-center justify-between py-2 text-sm"
+                        >
+                          <span className="text-hot-gray-700">
+                            {inv.email}{' '}
+                            <span className="text-hot-gray-400">· {inv.role}</span>
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => handleCancelInvite(inv.id)}
+                            className="text-xs text-hot-red-600 hover:underline"
+                          >
+                            {t('cancelInvite')}
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                <hr className="border-hot-gray-200" />
+                </div>
+              )
+            }
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default OrganizationDetailPage;

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -1,0 +1,359 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import GroupCard from '../components/GroupCard';
+import { useLanguage } from '../contexts/LanguageContext';
+import type { GroupSummary, MyInvitation } from '../types/groups';
+import { backendUrl, readError } from '../utils/api';
+
+function OrganizationsPage() {
+  const navigate = useNavigate();
+  const { t } = useLanguage();
+
+  const [groups, setGroups] = useState<GroupSummary[]>([]);
+  const [invitations, setInvitations] = useState<MyInvitation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Create/request form
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState('');
+  const [contactEmail, setContactEmail] = useState('');
+  const [website, setWebsite] = useState('');
+  const [description, setDescription] = useState('');
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [bannerFile, setBannerFile] = useState<File | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const goLogin = useCallback(() => {
+    navigate('/?return_to=' + encodeURIComponent(window.location.href));
+  }, [navigate]);
+
+  const fetchGroups = useCallback(async () => {
+    try {
+      setError(null);
+      const response = await fetch(`${backendUrl}/groups?type=organization`, {
+        credentials: 'include',
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      const data = await response.json();
+      setGroups(data.groups || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  }, [goLogin]);
+
+  const fetchInvitations = useCallback(async () => {
+    try {
+      const response = await fetch(`${backendUrl}/me/invitations`, {
+        credentials: 'include',
+      });
+      if (response.ok) {
+        const data: MyInvitation[] = await response.json();
+        // Only organizations use the invitation flow
+        setInvitations(data.filter((inv) => inv.group_type === 'organization'));
+      }
+    } catch {
+      // Non-critical: invitations tray just stays empty
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchGroups();
+    fetchInvitations();
+  }, [fetchGroups, fetchInvitations]);
+
+  const uploadImage = async (
+    id: string,
+    kind: 'avatar' | 'banner',
+    file: File,
+  ) => {
+    const form = new FormData();
+    form.append('file', file);
+    const res = await fetch(`${backendUrl}/groups/${id}/${kind}`, {
+      method: 'PUT',
+      credentials: 'include',
+      body: form,
+    });
+    if (!res.ok) throw new Error(await readError(res));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const response = await fetch(`${backendUrl}/groups`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'organization',
+          name,
+          contact_email: contactEmail || undefined,
+          website: website || undefined,
+          description: description || undefined,
+        }),
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      const created = await response.json();
+
+      // Org exists now — reset the form regardless of the image outcome so a
+      // failed upload can't lead to a duplicate org on retry.
+      setShowForm(false);
+      setName('');
+      setContactEmail('');
+      setWebsite('');
+      setDescription('');
+      const avatar = avatarFile;
+      const banner = bannerFile;
+      setAvatarFile(null);
+      setBannerFile(null);
+
+      // Upload images best-effort: if one fails the org is still created and it
+      // can be added later from the org's Details page.
+      try {
+        if (avatar) await uploadImage(created.id, 'avatar', avatar);
+        if (banner) await uploadImage(created.id, 'banner', banner);
+      } catch {
+        setError(
+          'Organization created, but the image upload failed — you can add it later from the org page.',
+        );
+      }
+
+      setSuccess(t('orgRequestSubmitted'));
+      await fetchGroups();
+      setTimeout(() => setSuccess(null), 4000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const respondToInvitation = async (
+    invitation: MyInvitation,
+    action: 'accept' | 'decline',
+  ) => {
+    try {
+      const response = await fetch(
+        `${backendUrl}/me/invitations/${invitation.token}/${action}`,
+        { method: 'POST', credentials: 'include' },
+      );
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      setInvitations((prev) => prev.filter((inv) => inv.id !== invitation.id));
+      if (action === 'accept') await fetchGroups();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="animate-spin rounded-full h-12 w-12 border-4 border-hot-red-600 border-t-transparent"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      {error && (
+        <div className="bg-hot-red-50 border border-hot-red-200 text-hot-red-700 px-4 py-3 rounded-lg">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg">
+          {success}
+        </div>
+      )}
+
+      {/* Pending invitations tray */}
+      {invitations.length > 0 && (
+        <div className="bg-white rounded-xl shadow-xl p-6">
+          <h2 className="text-lg font-semibold text-hot-gray-900 mb-4">
+            {t('pendingInvitations')}
+          </h2>
+          <div className="divide-y divide-hot-gray-200">
+            {invitations.map((inv) => (
+              <div
+                key={inv.id}
+                className="flex items-center justify-between py-3 gap-3"
+              >
+                <div>
+                  <p className="text-sm font-medium text-hot-gray-900">
+                    {inv.group_name}
+                  </p>
+                  <p className="text-xs text-hot-gray-500">
+                    {t('invitedToJoin')} · {inv.role}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => respondToInvitation(inv, 'accept')}
+                    className="btn-success-small"
+                  >
+                    {t('accept')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => respondToInvitation(inv, 'decline')}
+                    className="btn-secondary-small"
+                  >
+                    {t('decline')}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Organizations list */}
+      <div className="bg-white rounded-xl shadow-xl p-6">
+        <div className="flex items-center justify-between mb-1">
+          <h1 className="text-lg font-semibold text-hot-gray-900">
+            {t('organizations')}
+          </h1>
+          <button
+            type="button"
+            onClick={() => setShowForm((v) => !v)}
+            className="btn-primary-hot w-auto px-4 py-2 text-sm"
+          >
+            {t('requestOrganization')}
+          </button>
+        </div>
+        <p className="text-sm text-hot-gray-500 mb-4">
+          {t('organizationsSubtitle')}
+        </p>
+
+        {groups.length === 0 ? (
+          <p className="text-sm text-hot-gray-500 py-6 text-center">
+            {t('noOrganizations')}
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {groups.map((group) => (
+              <GroupCard
+                key={group.id}
+                group={group}
+                to={`/organizations/${group.id}`}
+                showStatus
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Request organization form */}
+      {showForm && (
+        <div className="bg-white rounded-xl shadow-xl p-6">
+          <h2 className="text-lg font-semibold text-hot-gray-900 mb-4">
+            {t('requestOrgTitle')}
+          </h2>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                {t('name')}
+              </label>
+              <input
+                type="text"
+                required
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="input-field"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                {t('contactEmail')}
+              </label>
+              <input
+                type="email"
+                value={contactEmail}
+                onChange={(e) => setContactEmail(e.target.value)}
+                className="input-field"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                {t('website')}
+              </label>
+              <input
+                type="url"
+                value={website}
+                onChange={(e) => setWebsite(e.target.value)}
+                placeholder="https://example.org"
+                className="input-field"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                {t('description')}
+              </label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={3}
+                className="input-field"
+              />
+            </div>
+            <p className="text-xs text-hot-gray-400">
+              You can invite members from the org page once it's approved.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                  {t('avatarLabel')}
+                </label>
+                <input
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  onChange={(e) => setAvatarFile(e.target.files?.[0] ?? null)}
+                  className="text-sm text-hot-gray-600"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                  {t('bannerLabel')}
+                </label>
+                <input
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  onChange={(e) => setBannerFile(e.target.files?.[0] ?? null)}
+                  className="text-sm text-hot-gray-600"
+                />
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="submit"
+                disabled={submitting}
+                className="btn-primary-hot w-auto px-4 py-2 text-sm disabled:opacity-50"
+              >
+                {submitting ? t('saving') : t('submitRequest')}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowForm(false)}
+                className="btn-secondary-hot w-auto px-4 py-2 text-sm"
+              >
+                {t('cancel')}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default OrganizationsPage;

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -2,8 +2,6 @@ import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { Hanko } from "@teamhanko/hanko-elements";
 import { validateReturnTo } from "../utils/validateReturnTo";
-import "@hotosm/tool-menu";
-import hotLogo from "../assets/images/hot-logo.svg";
 import { useLanguage } from "../contexts/LanguageContext";
 import { LANGUAGES } from "../translations";
 
@@ -69,19 +67,6 @@ function ProfilePage() {
   // Get return URL from query params (passed by web component)
   const urlParams = new URLSearchParams(window.location.search);
   const returnTo = validateReturnTo(urlParams.get("return_to"));
-
-  // Determine back button text and destination
-  const backInfo = (() => {
-    if (!returnTo) return null;
-    try {
-      const url = new URL(returnTo);
-      const appName = url.hostname.split(".")[0];
-      const label = appName.charAt(0).toUpperCase() + appName.slice(1);
-      return { url: returnTo, label };
-    } catch {
-      return null;
-    }
-  })();
 
   // Fetch profile on mount
   useEffect(() => {
@@ -329,28 +314,8 @@ function ProfilePage() {
   }
 
   return (
-    <div className="min-h-screen bg-hot-gray-50 py-8 px-4">
+    <div>
       <div className="max-w-2xl mx-auto">
-        {/* Header */}
-        <div className="bg-white rounded-xl shadow-xl p-6 mb-6">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              <img src={hotLogo} alt="HOT" className="h-10" />
-            </div>
-            <div className="flex items-center gap-4">
-              {backInfo && (
-                <button
-                  onClick={() => (window.location.href = backInfo.url)}
-                  className="text-hot-gray-1000 hover:text-hot-gray-900 text-sm transition-colors"
-                >
-                  {t("goBack")}
-                </button>
-              )}
-              <hotosm-tool-menu lang={language} />
-            </div>
-          </div>
-        </div>
-
         {/* Messages */}
         {error && (
           <div className="bg-hot-red-50 border border-hot-red-200 text-hot-red-700 px-4 py-3 rounded-lg mb-6">

--- a/frontend/src/pages/TeamDetailPage.tsx
+++ b/frontend/src/pages/TeamDetailPage.tsx
@@ -1,0 +1,360 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import MembersPanel from '../components/MembersPanel';
+import { useLanguage } from '../contexts/LanguageContext';
+import type { GroupResponse, MemberRole } from '../types/groups';
+import { backendUrl, readError } from '../utils/api';
+
+function TeamDetailPage() {
+  const { id = '' } = useParams();
+  const navigate = useNavigate();
+  const { t } = useLanguage();
+
+  const [group, setGroup] = useState<GroupResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<'details' | 'members'>('details');
+
+  // Editable details form
+  const [description, setDescription] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Name change (applied directly for teams)
+  const [editingName, setEditingName] = useState(false);
+  const [newName, setNewName] = useState('');
+
+  // Add member form (teams add members directly by Hanko user ID)
+  const [memberEmail, setMemberEmail] = useState('');
+  const [memberRole, setMemberRole] = useState<MemberRole>('member');
+
+  const goLogin = useCallback(() => {
+    navigate('/?return_to=' + encodeURIComponent(window.location.href));
+  }, [navigate]);
+
+  const fetchGroup = useCallback(async () => {
+    try {
+      setError(null);
+      const response = await fetch(`${backendUrl}/groups/${id}`, {
+        credentials: 'include',
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      const data: GroupResponse = await response.json();
+      setGroup(data);
+      setDescription(data.description || '');
+      setIsPublic(data.is_public);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  }, [id, goLogin]);
+
+  useEffect(() => {
+    fetchGroup();
+  }, [fetchGroup]);
+
+  const canManage = group?.role === 'owner' || group?.role === 'manager';
+  const canDelete = group?.role === 'owner';
+
+  const flashSuccess = (msg: string) => {
+    setSuccess(msg);
+    setTimeout(() => setSuccess(null), 3000);
+  };
+
+  const handleSaveDetails = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch(`${backendUrl}/groups/${id}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          description: description || null,
+          is_public: isPublic,
+        }),
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      setGroup(await response.json());
+      flashSuccess(t('detailsSaved'));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleChangeName = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const response = await fetch(`${backendUrl}/groups/${id}/name-change`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName }),
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      setGroup(await response.json());
+      setEditingName(false);
+      setNewName('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm(t('deleteGroupConfirm'))) return;
+    try {
+      const response = await fetch(`${backendUrl}/groups/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      navigate('/teams');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  const handleAddMember = async (e: React.FormEvent, onChanged: () => void) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const response = await fetch(`${backendUrl}/groups/${id}/members`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: memberEmail, role: memberRole }),
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      setMemberEmail('');
+      setMemberRole('member');
+      onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="animate-spin rounded-full h-12 w-12 border-4 border-hot-red-600 border-t-transparent"></div>
+      </div>
+    );
+  }
+
+  if (!group) {
+    return (
+      <div className="max-w-3xl mx-auto">
+        <div className="bg-hot-red-50 border border-hot-red-200 text-hot-red-700 px-4 py-3 rounded-lg">
+          {error || 'Not found'}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      <button
+        type="button"
+        onClick={() => navigate('/teams')}
+        className="text-sm text-hot-gray-500 hover:text-hot-red-600 transition-colors"
+      >
+        ← {t('navTeams')}
+      </button>
+
+      {error && (
+        <div className="bg-hot-red-50 border border-hot-red-200 text-hot-red-700 px-4 py-3 rounded-lg">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg">
+          {success}
+        </div>
+      )}
+
+      {/* Header — teams have just a name (no logo/banner, no approval status) */}
+      <div className="bg-white rounded-xl shadow-xl p-6">
+        <h1 className="text-xl font-semibold text-hot-gray-900">
+          {group.name}
+        </h1>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => setActiveTab('details')}
+          className={`admin-tab ${activeTab === 'details' ? 'active' : ''}`}
+        >
+          {t('detailsTab')}
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab('members')}
+          className={`admin-tab ${activeTab === 'members' ? 'active' : ''}`}
+        >
+          {t('membersTab')} ({group.members_count})
+        </button>
+      </div>
+
+      {activeTab === 'details' && (
+        <div className="bg-white rounded-xl shadow-xl p-6 space-y-6">
+          {/* Name change */}
+          <div>
+            <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+              {t('name')}
+            </label>
+            {editingName ? (
+              <form onSubmit={handleChangeName} className="flex gap-2">
+                <input
+                  type="text"
+                  required
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  className="input-field"
+                />
+                <button
+                  type="submit"
+                  className="btn-primary-hot w-auto px-4 py-2 text-sm"
+                >
+                  {t('saveChanges')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setEditingName(false)}
+                  className="btn-secondary-hot w-auto px-4 py-2 text-sm"
+                >
+                  {t('cancel')}
+                </button>
+              </form>
+            ) : (
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-hot-gray-900">{group.name}</span>
+                {canManage && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setNewName(group.name);
+                      setEditingName(true);
+                    }}
+                    className="text-sm text-hot-red-600 hover:underline"
+                  >
+                    {t('changeName')}
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+
+          {canManage ? (
+            <form onSubmit={handleSaveDetails} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                  {t('description')}
+                </label>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  rows={3}
+                  className="input-field"
+                />
+              </div>
+              {/* Public-profile toggle hidden until portal public profiles ship.
+                  Teams have no logo/banner. */}
+
+              <div className="flex items-center justify-between pt-2">
+                <button
+                  type="submit"
+                  disabled={saving}
+                  className="btn-primary-hot w-auto px-4 py-2 text-sm disabled:opacity-50"
+                >
+                  {saving ? t('saving') : t('saveChanges')}
+                </button>
+                {canDelete && (
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    className="btn-danger-small"
+                  >
+                    {t('deleteGroupBtn')}
+                  </button>
+                )}
+              </div>
+            </form>
+          ) : (
+            <dl className="space-y-3 text-sm">
+              <div>
+                <dt className="font-medium text-hot-gray-700">
+                  {t('description')}
+                </dt>
+                <dd className="text-hot-gray-600 whitespace-pre-line">
+                  {group.description || '—'}
+                </dd>
+              </div>
+            </dl>
+          )}
+        </div>
+      )}
+
+      {activeTab === 'members' && (
+        <div className="bg-white rounded-xl shadow-xl p-6">
+          <MembersPanel
+            groupId={id}
+            viewerRole={group.role}
+            onLeft={() => navigate('/teams')}
+            renderAdd={(onChanged) => (
+              <div className="space-y-4 mb-2">
+                <form
+                  onSubmit={(e) => handleAddMember(e, onChanged)}
+                  className="flex flex-wrap items-end gap-2"
+                >
+                  <div className="flex-1 min-w-[180px]">
+                    <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                      {t('addMemberByEmail')}
+                    </label>
+                    <input
+                      type="email"
+                      required
+                      value={memberEmail}
+                      onChange={(e) => setMemberEmail(e.target.value)}
+                      placeholder="person@example.org"
+                      className="input-field"
+                    />
+                  </div>
+                  <select
+                    value={memberRole}
+                    onChange={(e) => setMemberRole(e.target.value as MemberRole)}
+                    className="input-field w-auto"
+                  >
+                    <option value="member">{t('roleMember')}</option>
+                    <option value="manager">{t('roleManager')}</option>
+                  </select>
+                  <button
+                    type="submit"
+                    className="btn-primary-hot w-auto px-4 py-2 text-sm"
+                  >
+                    {t('addBtn')}
+                  </button>
+                </form>
+                <hr className="border-hot-gray-200" />
+              </div>
+            )}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TeamDetailPage;

--- a/frontend/src/pages/TeamsPage.tsx
+++ b/frontend/src/pages/TeamsPage.tsx
@@ -1,0 +1,280 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import GroupCard from '../components/GroupCard';
+import { useLanguage } from '../contexts/LanguageContext';
+import type { GroupSummary } from '../types/groups';
+import { backendUrl, readError } from '../utils/api';
+
+function TeamsPage() {
+  const navigate = useNavigate();
+  const { t } = useLanguage();
+
+  const [groups, setGroups] = useState<GroupSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  // Create form
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [memberInput, setMemberInput] = useState('');
+  const [members, setMembers] = useState<
+    { email: string; name: string | null }[]
+  >([]);
+  const [memberError, setMemberError] = useState<string | null>(null);
+  const [checkingMember, setCheckingMember] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const goLogin = useCallback(() => {
+    navigate('/?return_to=' + encodeURIComponent(window.location.href));
+  }, [navigate]);
+
+  const fetchGroups = useCallback(async () => {
+    try {
+      setError(null);
+      const response = await fetch(`${backendUrl}/groups?type=team`, {
+        credentials: 'include',
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      const data = await response.json();
+      setGroups(data.groups || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  }, [goLogin]);
+
+  useEffect(() => {
+    fetchGroups();
+  }, [fetchGroups]);
+
+  const handleAddMember = async () => {
+    const email = memberInput.trim().toLowerCase();
+    setMemberError(null);
+    if (!email) return;
+    if (members.some((m) => m.email === email)) {
+      setMemberError('Already added.');
+      return;
+    }
+    setCheckingMember(true);
+    try {
+      const response = await fetch(
+        `${backendUrl}/users/lookup?email=${encodeURIComponent(email)}`,
+        { credentials: 'include' },
+      );
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      const data = await response.json();
+      if (!data.exists) {
+        setMemberError('No HOT account found with that email.');
+        return;
+      }
+      setMembers((prev) => [...prev, { email, name: data.name }]);
+      setMemberInput('');
+    } catch (err) {
+      setMemberError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setCheckingMember(false);
+    }
+  };
+
+  const removeMember = (email: string) => {
+    setMembers((prev) => prev.filter((m) => m.email !== email));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const response = await fetch(`${backendUrl}/groups`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'team',
+          name,
+          description: description || undefined,
+          member_emails: members.map((m) => m.email),
+        }),
+      });
+      if (response.status === 401) return goLogin();
+      if (!response.ok) throw new Error(await readError(response));
+      setShowForm(false);
+      setName('');
+      setDescription('');
+      setMembers([]);
+      setMemberInput('');
+      await fetchGroups();
+      setSuccess(t('teamCreated'));
+      setTimeout(() => setSuccess(null), 3000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="animate-spin rounded-full h-12 w-12 border-4 border-hot-red-600 border-t-transparent"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      {error && (
+        <div className="bg-hot-red-50 border border-hot-red-200 text-hot-red-700 px-4 py-3 rounded-lg">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg">
+          {success}
+        </div>
+      )}
+
+      {/* Teams list */}
+      <div className="bg-white rounded-xl shadow-xl p-6">
+        <div className="flex items-center justify-between mb-1">
+          <h1 className="text-lg font-semibold text-hot-gray-900">
+            {t('teams')}
+          </h1>
+          <button
+            type="button"
+            onClick={() => setShowForm((v) => !v)}
+            className="btn-primary-hot w-auto px-4 py-2 text-sm"
+          >
+            {t('createTeam')}
+          </button>
+        </div>
+        <p className="text-sm text-hot-gray-500 mb-4">{t('teamsSubtitle')}</p>
+
+        {groups.length === 0 ? (
+          <p className="text-sm text-hot-gray-500 py-6 text-center">
+            {t('noTeams')}
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {groups.map((group) => (
+              <GroupCard
+                key={group.id}
+                group={group}
+                to={`/teams/${group.id}`}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Create team form */}
+      {showForm && (
+        <div className="bg-white rounded-xl shadow-xl p-6">
+          <h2 className="text-lg font-semibold text-hot-gray-900 mb-4">
+            {t('createTeamTitle')}
+          </h2>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                {t('name')}
+              </label>
+              <input
+                type="text"
+                required
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="input-field"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                {t('description')}
+              </label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={3}
+                className="input-field"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-hot-gray-700 mb-1">
+                {t('membersTab')}
+              </label>
+              <div className="flex gap-2">
+                <input
+                  type="email"
+                  value={memberInput}
+                  onChange={(e) => setMemberInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      handleAddMember();
+                    }
+                  }}
+                  placeholder="person@example.org"
+                  className="input-field flex-1"
+                />
+                <button
+                  type="button"
+                  onClick={handleAddMember}
+                  disabled={checkingMember}
+                  className="btn-secondary-hot w-auto px-4 py-2 text-sm disabled:opacity-50"
+                >
+                  {checkingMember ? '…' : 'Add'}
+                </button>
+              </div>
+              {memberError && (
+                <p className="text-xs text-hot-red-600 mt-1">{memberError}</p>
+              )}
+              {members.length > 0 && (
+                <div className="flex flex-wrap gap-2 mt-2">
+                  {members.map((m) => (
+                    <span
+                      key={m.email}
+                      className="inline-flex items-center gap-1 text-xs bg-hot-gray-100 text-hot-gray-700 rounded-full px-2 py-1"
+                    >
+                      {m.name || m.email}
+                      <button
+                        type="button"
+                        onClick={() => removeMember(m.email)}
+                        className="text-hot-gray-400 hover:text-hot-red-600"
+                        aria-label="Remove"
+                      >
+                        ×
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="submit"
+                disabled={submitting}
+                className="btn-primary-hot w-auto px-4 py-2 text-sm disabled:opacity-50"
+              >
+                {submitting ? t('saving') : t('create')}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowForm(false)}
+                className="btn-secondary-hot w-auto px-4 py-2 text-sm"
+              >
+                {t('cancel')}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TeamsPage;

--- a/frontend/src/translations.ts
+++ b/frontend/src/translations.ts
@@ -78,6 +78,103 @@ export interface Translations {
   // Common
   login: string;
   no_existing_osm_account: string;
+
+  // Teams & Organizations — navigation / layout
+  // (optional: missing keys fall back to English via the t() helper)
+  hotAccount?: string;
+  navProfile?: string;
+  navOrganizations?: string;
+  navTeams?: string;
+  navUsers?: string;
+  navAdmin?: string;
+
+  // Organizations
+  organizations?: string;
+  organizationsSubtitle?: string;
+  requestOrganization?: string;
+  requestOrgTitle?: string;
+  name?: string;
+  contactEmail?: string;
+  website?: string;
+  description?: string;
+  submitRequest?: string;
+  orgRequestSubmitted?: string;
+  noOrganizations?: string;
+
+  // Invitations
+  pendingInvitations?: string;
+  invitedToJoin?: string;
+  accept?: string;
+  decline?: string;
+
+  // Teams
+  teams?: string;
+  teamsSubtitle?: string;
+  createTeam?: string;
+  createTeamTitle?: string;
+  teamCreated?: string;
+  memberIdsLabel?: string;
+  memberIdsHint?: string;
+  noTeams?: string;
+  create?: string;
+
+  // Group detail (shared)
+  detailsTab?: string;
+  membersTab?: string;
+  changeName?: string;
+  nameChangePending?: string;
+  avatarLabel?: string;
+  bannerLabel?: string;
+  detailsSaved?: string;
+  publicGroup?: string;
+  deleteGroupBtn?: string;
+  deleteGroupConfirm?: string;
+
+  // Members
+  addMemberByEmail?: string;
+  addMemberById?: string;
+  hankoUserIdLabel?: string;
+  inviteBtn?: string;
+  addBtn?: string;
+  removeMember?: string;
+  leaveGroup?: string;
+  removeMemberConfirm?: string;
+  leaveGroupConfirm?: string;
+  transferOwnershipConfirm?: string;
+  memberSince?: string;
+  noMembers?: string;
+  sentInvitations?: string;
+  cancelInvite?: string;
+  cancelInviteConfirm?: string;
+  previous?: string;
+  next?: string;
+
+  // Member roles
+  roleOwner?: string;
+  roleManager?: string;
+  roleMember?: string;
+
+  // Group statuses
+  statusPending?: string;
+  statusApproved?: string;
+  statusActive?: string;
+  statusRejected?: string;
+
+  // Accept invite page
+  acceptingInvite?: string;
+  inviteAccepted?: string;
+  inviteFailed?: string;
+  goToGroup?: string;
+  noInviteToken?: string;
+
+  // Admin tabs (users / organizations management)
+  adminUsersTab?: string;
+  adminOrganizationsTab?: string;
+  makeAccountManager?: string;
+  removeAccountManager?: string;
+  approveBtn?: string;
+  rejectBtn?: string;
+  approveNameBtn?: string;
 }
 
 export const translations: Record<string, Translations> = {
@@ -150,6 +247,82 @@ export const translations: Record<string, Translations> = {
     cancel: "Cancel",
     login: "Login",
     no_existing_osm_account: "No existing account found for your OSM user. Please select 'Continue' to create a new account.",
+    hotAccount: "HOT Account",
+    navProfile: "Profile",
+    navOrganizations: "Organizations",
+    navTeams: "Teams",
+    navUsers: "Users",
+    navAdmin: "Admin",
+    organizations: "Organizations",
+    organizationsSubtitle: "Official organizations you belong to",
+    requestOrganization: "Request organization",
+    requestOrgTitle: "Request a new organization",
+    name: "Name",
+    contactEmail: "Contact email",
+    website: "Website",
+    description: "Description",
+    submitRequest: "Submit request",
+    orgRequestSubmitted: "Your organization request was submitted and is pending approval.",
+    noOrganizations: "You don't belong to any organizations yet.",
+    pendingInvitations: "Pending invitations",
+    invitedToJoin: "You've been invited to join",
+    accept: "Accept",
+    decline: "Decline",
+    teams: "Teams",
+    teamsSubtitle: "Informal teams you belong to",
+    createTeam: "Create team",
+    createTeamTitle: "Create a new team",
+    teamCreated: "Team created.",
+    memberIdsLabel: "Member IDs (optional)",
+    memberIdsHint: "Comma-separated Hanko user IDs",
+    noTeams: "You don't belong to any teams yet.",
+    create: "Create",
+    detailsTab: "Details",
+    membersTab: "Members",
+    changeName: "Change name",
+    nameChangePending: "Name change pending approval",
+    avatarLabel: "Avatar",
+    bannerLabel: "Banner",
+    detailsSaved: "Changes saved.",
+    publicGroup: "Public",
+    deleteGroupBtn: "Delete",
+    deleteGroupConfirm: "Are you sure? This cannot be undone.",
+    addMemberByEmail: "Invite by email",
+    addMemberById: "Add member by ID",
+    hankoUserIdLabel: "Hanko user ID",
+    inviteBtn: "Invite",
+    addBtn: "Add",
+    removeMember: "Remove",
+    leaveGroup: "Leave",
+    removeMemberConfirm: "Remove this member?",
+    leaveGroupConfirm: "Leave this group?",
+    transferOwnershipConfirm: "Transfer ownership to this member?",
+    memberSince: "Member since",
+    noMembers: "No members yet.",
+    sentInvitations: "Pending invitations",
+    cancelInvite: "Cancel",
+    cancelInviteConfirm: "Cancel this invitation?",
+    previous: "Previous",
+    next: "Next",
+    roleOwner: "Owner",
+    roleManager: "Manager",
+    roleMember: "Member",
+    statusPending: "Pending",
+    statusApproved: "Approved",
+    statusActive: "Active",
+    statusRejected: "Rejected",
+    acceptingInvite: "Accepting invitation...",
+    inviteAccepted: "Invitation accepted!",
+    inviteFailed: "Could not accept the invitation.",
+    goToGroup: "Go to organizations",
+    noInviteToken: "No invitation token provided.",
+    adminUsersTab: "Users",
+    adminOrganizationsTab: "Organizations",
+    makeAccountManager: "Make account manager",
+    removeAccountManager: "Remove account manager",
+    approveBtn: "Approve",
+    rejectBtn: "Reject",
+    approveNameBtn: "Approve name",
   },
   es: {
     welcomeTo: "Bienvenido a HOT's",
@@ -221,6 +394,82 @@ export const translations: Record<string, Translations> = {
     cancel: "Cancelar",
     login: "Inicio de sesión",
     no_existing_osm_account: "No se encontró una cuenta existente para tu usuario de OSM. Por favor selecciona 'Continuar' para crear una nueva cuenta.",
+    hotAccount: "Cuenta HOT",
+    navProfile: "Perfil",
+    navOrganizations: "Organizaciones",
+    navTeams: "Equipos",
+    navUsers: "Usuarios",
+    navAdmin: "Admin",
+    organizations: "Organizaciones",
+    organizationsSubtitle: "Organizaciones oficiales a las que perteneces",
+    requestOrganization: "Solicitar organización",
+    requestOrgTitle: "Solicitar una nueva organización",
+    name: "Nombre",
+    contactEmail: "Correo de contacto",
+    website: "Sitio web",
+    description: "Descripción",
+    submitRequest: "Enviar solicitud",
+    orgRequestSubmitted: "Tu solicitud de organización fue enviada y está pendiente de aprobación.",
+    noOrganizations: "Todavía no perteneces a ninguna organización.",
+    pendingInvitations: "Invitaciones pendientes",
+    invitedToJoin: "Te invitaron a unirte",
+    accept: "Aceptar",
+    decline: "Rechazar",
+    teams: "Equipos",
+    teamsSubtitle: "Equipos informales a los que perteneces",
+    createTeam: "Crear equipo",
+    createTeamTitle: "Crear un nuevo equipo",
+    teamCreated: "Equipo creado.",
+    memberIdsLabel: "IDs de miembros (opcional)",
+    memberIdsHint: "IDs de usuario de Hanko separados por comas",
+    noTeams: "Todavía no perteneces a ningún equipo.",
+    create: "Crear",
+    detailsTab: "Detalles",
+    membersTab: "Miembros",
+    changeName: "Cambiar nombre",
+    nameChangePending: "Cambio de nombre pendiente de aprobación",
+    avatarLabel: "Avatar",
+    bannerLabel: "Banner",
+    detailsSaved: "Cambios guardados.",
+    publicGroup: "Público",
+    deleteGroupBtn: "Eliminar",
+    deleteGroupConfirm: "¿Estás seguro? Esto no se puede deshacer.",
+    addMemberByEmail: "Invitar por email",
+    addMemberById: "Agregar miembro por ID",
+    hankoUserIdLabel: "ID de usuario Hanko",
+    inviteBtn: "Invitar",
+    addBtn: "Agregar",
+    removeMember: "Quitar",
+    leaveGroup: "Salir",
+    removeMemberConfirm: "¿Quitar a este miembro?",
+    leaveGroupConfirm: "¿Salir de este grupo?",
+    transferOwnershipConfirm: "¿Transferir la propiedad a este miembro?",
+    memberSince: "Miembro desde",
+    noMembers: "Todavía no hay miembros.",
+    sentInvitations: "Invitaciones enviadas",
+    cancelInvite: "Cancelar",
+    cancelInviteConfirm: "¿Cancelar esta invitación?",
+    previous: "Anterior",
+    next: "Siguiente",
+    roleOwner: "Propietario",
+    roleManager: "Gestor",
+    roleMember: "Miembro",
+    statusPending: "Pendiente",
+    statusApproved: "Aprobada",
+    statusActive: "Activa",
+    statusRejected: "Rechazada",
+    acceptingInvite: "Aceptando invitación...",
+    inviteAccepted: "¡Invitación aceptada!",
+    inviteFailed: "No se pudo aceptar la invitación.",
+    goToGroup: "Ir a organizaciones",
+    noInviteToken: "No se proporcionó un token de invitación.",
+    adminUsersTab: "Usuarios",
+    adminOrganizationsTab: "Organizaciones",
+    makeAccountManager: "Hacer gestor de cuentas",
+    removeAccountManager: "Quitar gestor de cuentas",
+    approveBtn: "Aprobar",
+    rejectBtn: "Rechazar",
+    approveNameBtn: "Aprobar nombre",
   },
   fr: {
     welcomeTo: "Bienvenue sur HOT's",
@@ -291,6 +540,82 @@ export const translations: Record<string, Translations> = {
     cancel: "Annuler",
     login: "Connexion",
     no_existing_osm_account: "Aucun compte existant trouvé pour votre utilisateur OSM. Veuillez sélectionner 'Continuer' pour créer un nouveau compte.",
+    hotAccount: "Compte HOT",
+    navProfile: "Profil",
+    navOrganizations: "Organisations",
+    navTeams: "Équipes",
+    navUsers: "Utilisateurs",
+    navAdmin: "Admin",
+    organizations: "Organisations",
+    organizationsSubtitle: "Organisations officielles dont vous faites partie",
+    requestOrganization: "Demander une organisation",
+    requestOrgTitle: "Demander une nouvelle organisation",
+    name: "Nom",
+    contactEmail: "Email de contact",
+    website: "Site web",
+    description: "Description",
+    submitRequest: "Envoyer la demande",
+    orgRequestSubmitted: "Votre demande d'organisation a été envoyée et est en attente d'approbation.",
+    noOrganizations: "Vous ne faites partie d'aucune organisation pour l'instant.",
+    pendingInvitations: "Invitations en attente",
+    invitedToJoin: "Vous avez été invité à rejoindre",
+    accept: "Accepter",
+    decline: "Refuser",
+    teams: "Équipes",
+    teamsSubtitle: "Équipes informelles dont vous faites partie",
+    createTeam: "Créer une équipe",
+    createTeamTitle: "Créer une nouvelle équipe",
+    teamCreated: "Équipe créée.",
+    memberIdsLabel: "IDs des membres (facultatif)",
+    memberIdsHint: "IDs d'utilisateur Hanko séparés par des virgules",
+    noTeams: "Vous ne faites partie d'aucune équipe pour l'instant.",
+    create: "Créer",
+    detailsTab: "Détails",
+    membersTab: "Membres",
+    changeName: "Changer le nom",
+    nameChangePending: "Changement de nom en attente d'approbation",
+    avatarLabel: "Avatar",
+    bannerLabel: "Bannière",
+    detailsSaved: "Modifications enregistrées.",
+    publicGroup: "Public",
+    deleteGroupBtn: "Supprimer",
+    deleteGroupConfirm: "Êtes-vous sûr ? Cette action est irréversible.",
+    addMemberByEmail: "Inviter par email",
+    addMemberById: "Ajouter un membre par ID",
+    hankoUserIdLabel: "ID d'utilisateur Hanko",
+    inviteBtn: "Inviter",
+    addBtn: "Ajouter",
+    removeMember: "Retirer",
+    leaveGroup: "Quitter",
+    removeMemberConfirm: "Retirer ce membre ?",
+    leaveGroupConfirm: "Quitter ce groupe ?",
+    transferOwnershipConfirm: "Transférer la propriété à ce membre ?",
+    memberSince: "Membre depuis",
+    noMembers: "Aucun membre pour l'instant.",
+    sentInvitations: "Invitations envoyées",
+    cancelInvite: "Annuler",
+    cancelInviteConfirm: "Annuler cette invitation ?",
+    previous: "Précédent",
+    next: "Suivant",
+    roleOwner: "Propriétaire",
+    roleManager: "Gestionnaire",
+    roleMember: "Membre",
+    statusPending: "En attente",
+    statusApproved: "Approuvée",
+    statusActive: "Active",
+    statusRejected: "Rejetée",
+    acceptingInvite: "Acceptation de l'invitation...",
+    inviteAccepted: "Invitation acceptée !",
+    inviteFailed: "Impossible d'accepter l'invitation.",
+    goToGroup: "Aller aux organisations",
+    noInviteToken: "Aucun jeton d'invitation fourni.",
+    adminUsersTab: "Utilisateurs",
+    adminOrganizationsTab: "Organisations",
+    makeAccountManager: "Nommer gestionnaire de comptes",
+    removeAccountManager: "Retirer gestionnaire de comptes",
+    approveBtn: "Approuver",
+    rejectBtn: "Rejeter",
+    approveNameBtn: "Approuver le nom",
   },
   pt: {
     welcomeTo: "Bem-vindo ao HOT's",
@@ -360,6 +685,82 @@ export const translations: Record<string, Translations> = {
     cancel: "Cancelar",
     login: "Login",
     no_existing_osm_account: "Nenhuma conta existente encontrada para o seu usuário OSM. Por favor selecione 'Continuar' para criar uma nova conta.",
+    hotAccount: "Conta HOT",
+    navProfile: "Perfil",
+    navOrganizations: "Organizações",
+    navTeams: "Equipes",
+    navUsers: "Usuários",
+    navAdmin: "Admin",
+    organizations: "Organizações",
+    organizationsSubtitle: "Organizações oficiais às quais você pertence",
+    requestOrganization: "Solicitar organização",
+    requestOrgTitle: "Solicitar uma nova organização",
+    name: "Nome",
+    contactEmail: "E-mail de contato",
+    website: "Site",
+    description: "Descrição",
+    submitRequest: "Enviar solicitação",
+    orgRequestSubmitted: "Sua solicitação de organização foi enviada e está pendente de aprovação.",
+    noOrganizations: "Você ainda não pertence a nenhuma organização.",
+    pendingInvitations: "Convites pendentes",
+    invitedToJoin: "Você foi convidado para entrar",
+    accept: "Aceitar",
+    decline: "Recusar",
+    teams: "Equipes",
+    teamsSubtitle: "Equipes informais às quais você pertence",
+    createTeam: "Criar equipe",
+    createTeamTitle: "Criar uma nova equipe",
+    teamCreated: "Equipe criada.",
+    memberIdsLabel: "IDs de membros (opcional)",
+    memberIdsHint: "IDs de usuário Hanko separados por vírgulas",
+    noTeams: "Você ainda não pertence a nenhuma equipe.",
+    create: "Criar",
+    detailsTab: "Detalhes",
+    membersTab: "Membros",
+    changeName: "Alterar nome",
+    nameChangePending: "Alteração de nome pendente de aprovação",
+    avatarLabel: "Avatar",
+    bannerLabel: "Banner",
+    detailsSaved: "Alterações salvas.",
+    publicGroup: "Público",
+    deleteGroupBtn: "Excluir",
+    deleteGroupConfirm: "Tem certeza? Isso não pode ser desfeito.",
+    addMemberByEmail: "Convidar por e-mail",
+    addMemberById: "Adicionar membro por ID",
+    hankoUserIdLabel: "ID de usuário Hanko",
+    inviteBtn: "Convidar",
+    addBtn: "Adicionar",
+    removeMember: "Remover",
+    leaveGroup: "Sair",
+    removeMemberConfirm: "Remover este membro?",
+    leaveGroupConfirm: "Sair deste grupo?",
+    transferOwnershipConfirm: "Transferir a propriedade para este membro?",
+    memberSince: "Membro desde",
+    noMembers: "Ainda não há membros.",
+    sentInvitations: "Convites enviados",
+    cancelInvite: "Cancelar",
+    cancelInviteConfirm: "Cancelar este convite?",
+    previous: "Anterior",
+    next: "Próximo",
+    roleOwner: "Proprietário",
+    roleManager: "Gerente",
+    roleMember: "Membro",
+    statusPending: "Pendente",
+    statusApproved: "Aprovada",
+    statusActive: "Ativa",
+    statusRejected: "Rejeitada",
+    acceptingInvite: "Aceitando convite...",
+    inviteAccepted: "Convite aceito!",
+    inviteFailed: "Não foi possível aceitar o convite.",
+    goToGroup: "Ir para organizações",
+    noInviteToken: "Nenhum token de convite fornecido.",
+    adminUsersTab: "Usuários",
+    adminOrganizationsTab: "Organizações",
+    makeAccountManager: "Tornar gerente de contas",
+    removeAccountManager: "Remover gerente de contas",
+    approveBtn: "Aprovar",
+    rejectBtn: "Rejeitar",
+    approveNameBtn: "Aprovar nome",
   },
 };
 

--- a/frontend/src/types/groups.ts
+++ b/frontend/src/types/groups.ts
@@ -1,0 +1,71 @@
+// Shared types for Teams & Organizations (groups).
+
+export type GroupType = 'team' | 'organization';
+export type MemberRole = 'owner' | 'manager' | 'member';
+
+// Short shape returned by GET /groups
+export interface GroupSummary {
+  id: string;
+  type: GroupType;
+  slug: string;
+  name: string;
+  role: MemberRole | null;
+  status: string;
+  avatar_url: string | null;
+}
+
+// Full shape returned by GET /groups/{id} and the create/update endpoints
+export interface GroupResponse {
+  id: string;
+  type: GroupType;
+  name: string;
+  slug: string;
+  description: string | null;
+  contact_email: string | null;
+  website: string | null;
+  avatar_url: string | null;
+  banner_url: string | null;
+  status: string;
+  pending_name: string | null;
+  is_public: boolean;
+  created_by: string;
+  created_at: string;
+  updated_at: string | null;
+  role: MemberRole | null;
+  members_count: number;
+}
+
+export interface GroupMember {
+  hanko_user_id: string;
+  role: MemberRole;
+  first_name: string | null;
+  last_name: string | null;
+  picture_url: string | null;
+  email: string | null;
+  created_at: string;
+}
+
+export interface MembersResponse {
+  items: GroupMember[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+export interface Invitation {
+  id: string;
+  group_id: string;
+  email: string;
+  role: MemberRole;
+  status: string;
+  invited_by: string;
+  created_at: string;
+  expires_at: string;
+}
+
+// Invitation enriched with group info, returned by GET /me/invitations
+export interface MyInvitation extends Invitation {
+  token: string;
+  group_name: string;
+  group_type: GroupType;
+}

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,0 +1,16 @@
+// Shared helpers for talking to the login backend.
+// VITE_BACKEND_URL already includes the `/api` prefix (see .env), so paths are
+// appended without it, e.g. `${backendUrl}/groups`. Falls back to `/api` so the
+// Vite dev proxy can forward same-origin requests to the backend.
+export const backendUrl = import.meta.env.VITE_BACKEND_URL || '/api';
+
+// Backend errors are returned as { code, message }. Older admin endpoints use
+// { detail }. Read whichever is present, with a sensible fallback.
+export async function readError(response: Response): Promise<string> {
+  try {
+    const data = await response.json();
+    return data?.message || data?.detail || `Request failed (${response.status})`;
+  } catch {
+    return `Request failed (${response.status})`;
+  }
+}


### PR DESCRIPTION
Adds teams and organizations to the login service, the source of truth for group membership consumed by portal (and later ChatMap) through a documented REST API.

## What's included
- **Groups**: a single `groups` table for teams (informal) and organizations (official), with memberships (owner/manager/member), email-anchored invitations and slugs.
- **Account Manager** role (persisted; administrators implied) — approves organizations and lists users. New `Users` and `Orgs to approve` tabs in the admin panel, gated by role.
- **Organization flow**: request → account-manager approval → invite members by email (recipients accept). The owner is emailed on approve/reject (with reason).
- **Team flow**: created approved; members added directly by verified email.
- **Storage**: avatar/banner via S3 with a local filesystem fallback (Pillow → WEBP).
- **Consumer API**: `GET /api/groups`, membership check, public profiles.
- **Frontend**: account sidebar layout, organizations/teams pages, invitations inbox, admin tabs.
- **Tests**: new `app/tests/` suite (44 tests).

## Migrations
`003`–`007` (groups, memberships, invitations, account_managers, user slug). Additive, run on startup.

## New dependencies
`boto3`, `pillow` (backend) — the CI image must be rebuilt.

## Env vars for deploy
- `BACKEND_URL`, `FRONTEND_URL` = the public login URL (used for invitation email links and image URLs).
- `S3_*` for object storage (the local fallback is ephemeral on k8s).
